### PR TITLE
Bugfix: restore support for Color instances in Color.parse

### DIFF
--- a/src/function/index.test.ts
+++ b/src/function/index.test.ts
@@ -448,6 +448,40 @@ describe('exponential function', () => {
 
     });
 
+    test('zoom-and-property function, color', () => {
+        const f = createFunction({
+            type: 'exponential',
+            property: 'prop',
+            stops: [
+                [{zoom: 0, value: 0}, 'red'], [{zoom: 1, value: 0}, 'blue'],
+                [{zoom: 0, value: 1}, 'lime'], [{zoom: 1, value: 1}, 'magenta'],
+            ],
+        }, {
+            type: 'color',
+        }).evaluate;
+
+        expect(f({zoom: 0.0}, {properties: {prop: 0}})).toEqual(new Color(1, 0, 0, 1));
+        expect(f({zoom: 1.0}, {properties: {prop: 0}})).toEqual(new Color(0, 0, 1, 1));
+        expect(f({zoom: 0.5}, {properties: {prop: 1}})).toEqual(new Color(0.5, 0.5, 0.5, 1));
+    });
+
+    test('zoom-and-property function, padding', () => {
+        const f = createFunction({
+            type: 'exponential',
+            property: 'prop',
+            stops: [
+                [{zoom: 0, value: 0}, [2]], [{zoom: 1, value: 0}, [4]],
+                [{zoom: 0, value: 1}, [6]], [{zoom: 1, value: 1}, [8]],
+            ],
+        }, {
+            type: 'padding',
+        }).evaluate;
+
+        expect(f({zoom: 0.0}, {properties: {prop: 0}})).toEqual(new Padding([2, 2, 2, 2]));
+        expect(f({zoom: 1.0}, {properties: {prop: 0}})).toEqual(new Padding([4, 4, 4, 4]));
+        expect(f({zoom: 0.5}, {properties: {prop: 1}})).toEqual(new Padding([7, 7, 7, 7]));
+    });
+
 });
 
 describe('interval function', () => {

--- a/src/util/color.test.ts
+++ b/src/util/color.test.ts
@@ -55,6 +55,11 @@ describe('Color class', () => {
             expect(Color.parse('rgb(0deg,0,0)')).toBeUndefined();
         });
 
+        test('should accept instances of Color class', () => {
+            const color = new Color(0, 0, 0, 0);
+            expect(Color.parse(color)).toBe(color);
+        });
+
     });
 
     test('should keep a reference to the original color when alpha=0', () => {

--- a/src/util/color.ts
+++ b/src/util/color.ts
@@ -58,7 +58,12 @@ class Color {
      * @param input CSS color string to parse.
      * @returns A `Color` instance, or `undefined` if the input is not a valid color string.
      */
-    static parse(input: string | undefined | null): Color | undefined {
+    static parse(input: Color | string | undefined | null): Color | undefined {
+        // in zoom-and-property function input could be an instance of Color class
+        if (input instanceof Color) {
+            return input;
+        }
+
         if (typeof input !== 'string') {
             return;
         }


### PR DESCRIPTION
Restore support for already parsed `Color` instances as one of the valid `Color.parse` arguments as it is still required by some of the "functions".
Bug introduced in #94.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
