### PR TITLE
Bump version to 19.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## main
 
+## 19.1.0
+
+### ✨ Features and improvements
+
+* Use D50 white point instead of D65 in HCL/LAB color spaces [#146](https://github.com/maplibre/maplibre-style-spec/pull/146)
+* Automated migration of not-CSS-Color-specification-compliant hsl color values [#135](https://github.com/maplibre/maplibre-style-spec/pull/135)
+
 ## 19.0.1
 
 ### 🐛 Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
-  "version": "19.0.1",
+  "version": "19.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-style-spec",
-      "version": "19.0.1",
+      "version": "19.1.0",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "19.0.1",
+  "version": "19.1.0",
   "author": "MapLibre",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
Version bump to allow incorporating the hcl change in maplibre-gl.