### PR TITLE
Release 19.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## main
 
+
+## 19.2.0
+
+### ✨ Features and improvements
+
 * Remove mapbox reference from docs and test cases [#111](https://github.com/maplibre/maplibre-style-spec/issues/111)
+* Custom CSS Color 4 compliant css color parser [#175](https://github.com/maplibre/maplibre-style-spec/issues/175)
 
 ## 19.1.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
-  "version": "19.1.0",
+  "version": "19.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-style-spec",
-      "version": "19.1.0",
+      "version": "19.2.0",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "19.1.0",
+  "version": "19.2.0",
   "author": "MapLibre",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
The new addition is to allow for decimal values in color strings like rgb(). This is part of the CCS4 spec - until now such values were rounded to integers. (read more [here](https://github.com/maplibre/maplibre-gl-js/issues/2550#issuecomment-1554491765)) #175 

## Launch Checklist
 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!