### PR TITLE
Skip running color match regex, if not required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## 19.2.1
 ### ✨ Features and improvements
 
-* Skip running color match regex, if not required.
+* Skip running color match regex for hex color or rgb, if not required [#186](https://github.com/maplibre/maplibre-style-spec/pull/186)
 
 ## 19.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## main
+## 19.2.1
+### ✨ Features and improvements
 
+* Skip running color match regex, if not required.
 
 ## 19.2.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
-  "version": "19.2.0",
+  "version": "19.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-style-spec",
-      "version": "19.2.0",
+      "version": "19.2.1",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre gl styles",
-  "version": "19.2.0",
+  "version": "19.2.1",
   "author": "MapLibre",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
Color Parsing is in a critial hot path and is executed multiple times while style parsing. This PR brings in a small optimization.

Before running a expensive color match regex run a cheap validation. Tests shows a 98% improvement if color is specified in HSL format. There will be some improvement when color is specified in rgb format as well.
Test: https://jsbench.me/4blhzc953l/1

<img width="1186" alt="image" src="https://github.com/maplibre/maplibre-style-spec/assets/15951646/a37b1217-22ee-4f64-ae36-b91abc9ae6a9">

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [x] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
