### PR TITLE
remove dependency on @mapbox/point-geometry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/point-geometry": "^0.1.0",
         "@mapbox/unitbezier": "^0.0.1",
-        "@types/mapbox__point-geometry": "^0.1.2",
         "json-stringify-pretty-compact": "^3.0.0",
         "minimist": "^1.2.8",
         "rw": "^1.3.3",
@@ -1285,11 +1283,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
-    },
     "node_modules/@mapbox/unitbezier": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
@@ -1698,11 +1691,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
-    },
-    "node_modules/@types/mapbox__point-geometry": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz",
-      "integrity": "sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA=="
     },
     "node_modules/@types/node": {
       "version": "18.16.3",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,7 @@
   },
   "dependencies": {
     "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-    "@mapbox/point-geometry": "^0.1.0",
     "@mapbox/unitbezier": "^0.0.1",
-    "@types/mapbox__point-geometry": "^0.1.2",
     "json-stringify-pretty-compact": "^3.0.0",
     "minimist": "^1.2.8",
     "rw": "^1.3.3",

--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -28,8 +28,7 @@ import type {Result} from '../util/result';
 import type {InterpolationType} from './definitions/interpolate';
 import type {PropertyValueSpecification} from '../types.g';
 import type {FormattedSection} from './types/formatted';
-import type {Point2D} from "../point2d"
-
+import type {Point2D} from '../point2d';
 
 export type Feature = {
     readonly type: 1 | 2 | 3 | 'Unknown' | 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';

--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -27,11 +27,11 @@ import type {StylePropertySpecification} from '../style-spec';
 import type {Result} from '../util/result';
 import type {InterpolationType} from './definitions/interpolate';
 import type {PropertyValueSpecification} from '../types.g';
-import type { FormattedSection } from "./types/formatted";
+import type {FormattedSection} from './types/formatted';
 
 interface Point {
-  x: number;
-  y: number;
+    x: number;
+    y: number;
 }
 
 export type Feature = {

--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -29,10 +29,10 @@ import type {InterpolationType} from './definitions/interpolate';
 import type {PropertyValueSpecification} from '../types.g';
 import type {FormattedSection} from './types/formatted';
 
-interface Point {
+export type Point = {
     x: number;
     y: number;
-}
+};
 
 export type Feature = {
     readonly type: 1 | 2 | 3 | 'Unknown' | 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';

--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -28,11 +28,8 @@ import type {Result} from '../util/result';
 import type {InterpolationType} from './definitions/interpolate';
 import type {PropertyValueSpecification} from '../types.g';
 import type {FormattedSection} from './types/formatted';
+import type {Point2D} from "../point2d"
 
-export type Point = {
-    x: number;
-    y: number;
-};
 
 export type Feature = {
     readonly type: 1 | 2 | 3 | 'Unknown' | 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';
@@ -45,7 +42,7 @@ export type Feature = {
             'max': string;
         };
     };
-    readonly geometry?: Array<Array<Point>>;
+    readonly geometry?: Array<Array<Point2D>>;
 };
 
 export type FeatureState = {[_: string]: any};

--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -27,8 +27,12 @@ import type {StylePropertySpecification} from '../style-spec';
 import type {Result} from '../util/result';
 import type {InterpolationType} from './definitions/interpolate';
 import type {PropertyValueSpecification} from '../types.g';
-import type {FormattedSection} from './types/formatted';
-import type Point from '@mapbox/point-geometry';
+import type { FormattedSection } from "./types/formatted";
+
+interface Point {
+  x: number;
+  y: number;
+}
 
 export type Feature = {
     readonly type: 1 | 2 | 3 | 'Unknown' | 'Point' | 'MultiPoint' | 'LineString' | 'MultiLineString' | 'Polygon' | 'MultiPolygon';

--- a/src/feature_filter/feature_filter.test.ts
+++ b/src/feature_filter/feature_filter.test.ts
@@ -155,12 +155,12 @@ describe('filter', () => {
 
     test('expression, within', () => {
         const getPointFromLngLat = (lng, lat, canonical) => {
-          const p = MercatorCoordinate.fromLngLat({ lng, lat }, 0);
-          const tilesAtZoom = Math.pow(2, canonical.z);
-          return {
-            x: (p.x * tilesAtZoom - canonical.x) * EXTENT,
-            y: (p.y * tilesAtZoom - canonical.y) * EXTENT,
-          };
+            const p = MercatorCoordinate.fromLngLat({lng, lat}, 0);
+            const tilesAtZoom = Math.pow(2, canonical.z);
+            return {
+                x: (p.x * tilesAtZoom - canonical.x) * EXTENT,
+                y: (p.y * tilesAtZoom - canonical.y) * EXTENT,
+            };
         };
         const withinFilter =  createFilter(['within', {'type': 'Polygon', 'coordinates': [[[0, 0], [5, 0], [5, 5], [0, 5], [0, 0]]]}]);
         expect(withinFilter.needGeometry).toBe(true);

--- a/src/feature_filter/feature_filter.test.ts
+++ b/src/feature_filter/feature_filter.test.ts
@@ -1,7 +1,6 @@
 import {default as createFilter, isExpressionFilter} from '.';
 
 import convertFilter from './convert';
-import Point from '@mapbox/point-geometry';
 import MercatorCoordinate from '../coordinates/mercator_coordinate';
 import EXTENT from '../extent';
 import {ICanonicalTileID} from '../tiles_and_coordinates';
@@ -155,12 +154,13 @@ describe('filter', () => {
     });
 
     test('expression, within', () => {
-        const  getPointFromLngLat = (lng, lat, canonical) => {
-            const p = MercatorCoordinate.fromLngLat({lng, lat}, 0);
-            const tilesAtZoom = Math.pow(2, canonical.z);
-            return new Point(
-                (p.x * tilesAtZoom - canonical.x) * EXTENT,
-                (p.y * tilesAtZoom - canonical.y) * EXTENT);
+        const getPointFromLngLat = (lng, lat, canonical) => {
+          const p = MercatorCoordinate.fromLngLat({ lng, lat }, 0);
+          const tilesAtZoom = Math.pow(2, canonical.z);
+          return {
+            x: (p.x * tilesAtZoom - canonical.x) * EXTENT,
+            y: (p.y * tilesAtZoom - canonical.y) * EXTENT,
+          };
         };
         const withinFilter =  createFilter(['within', {'type': 'Polygon', 'coordinates': [[[0, 0], [5, 0], [5, 5], [0, 5], [0, 0]]]}]);
         expect(withinFilter.needGeometry).toBe(true);

--- a/src/point2d.ts
+++ b/src/point2d.ts
@@ -1,0 +1,5 @@
+
+export interface Point2D {
+    x: number;
+    y: number;
+}

--- a/src/tiles_and_coordinates.ts
+++ b/src/tiles_and_coordinates.ts
@@ -1,3 +1,5 @@
+import {Point2D} from './point2d';
+
 export interface ICanonicalTileID {
     z: number;
     x: number;
@@ -6,7 +8,7 @@ export interface ICanonicalTileID {
     equals(id: ICanonicalTileID): {};
     url(urls: Array<string>, pixelRatio: number, scheme: string | null): {};
     isChildOf(parent: ICanonicalTileID): {};
-    getTilePoint(coord: IMercatorCoordinate): {};
+    getTilePoint(coord: IMercatorCoordinate): Point2D;
     toString(): {};
 }
 

--- a/src/util/coordinates.ts
+++ b/src/util/coordinates.ts
@@ -1,3 +1,5 @@
+import {Point2D} from '../point2d';
+
 export interface IICanonicalTileID {
     z: number;
     x: number;
@@ -6,7 +8,7 @@ export interface IICanonicalTileID {
     equals(id: IICanonicalTileID): {};
     url(urls: Array<string>, pixelRatio: number, scheme: string | null): {};
     isChildOf(parent: IICanonicalTileID): {};
-    getTilePoint(coord: IMercatorCoordinate): {};
+    getTilePoint(coord: IMercatorCoordinate): Point2D;
     toString(): {};
 }
 


### PR DESCRIPTION
Mapbox has a particular implementation of 2D geometry. Make the style spec only demand an x, y point object.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [X] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
