### PR TITLE
Trim css color before parsing

### DIFF
--- a/src/util/parse_css_color.test.ts
+++ b/src/util/parse_css_color.test.ts
@@ -93,8 +93,8 @@ describe('parseCssColor', () => {
             expect(parse('rgb(0 51 0)')).toEqual(parse('rgba(0, 51, 0, 100%)'));
             expect(parse('rgb(0 51 0)')).toEqual(parse('rgba( 0, 51, 0, 100% )'));
             expect(parse('rgb(0 51 0)')).toEqual(parse('rgba( 00 ,51 ,0 ,100% )'));
-            expect(parse('rgb(0 51 0)')).toEqual(parse('rgb(.0 51 0 / 1)'));
-            expect(parse('rgb(0 51 0)')).toEqual(parse('rgb(0.0 51.0 0.0 / 1.0)'));
+            expect(parse('rgb(0 51 0)')).toEqual(parse(' rgb(.0 51 0 / 1)'));
+            expect(parse('rgb(0 51 0)')).toEqual(parse('rgb(0.0 51.0 0.0 / 1.0) '));
             expect(parse('rgb(0 51 0)')).toEqual(parse('rgb(0 51 0 / 1.0)'));
             expect(parse('rgb(0 51 0)')).toEqual(parse('RGB(0 51 0 / 100%)'));
             expect(parse('rgb(0 51 0)')).toEqual(parse('rgb(  0  51  0/1  )'));
@@ -262,8 +262,8 @@ describe('parseCssColor', () => {
             expect(parse('hsl(0 0% 0% / 0)')).toEqual(parse('hsl(0,0%,0%,+0)'));
             expect(parse('hsl(0 0% 0% / 0)')).toEqual(parse('hsla(0deg,0%,0%,-0)'));
             expect(parse('hsl(0 0% 0% / 0)')).toEqual(parse('hsla(0,0%,0%,0%)'));
-            expect(parse('hsl(0 0% 0% / 0)')).toEqual(parse('hsla(.0,.0%,.0%,.0%)'));
-            expect(parse('hsl(0 0% 0% / 0)')).toEqual(parse('hsla(  0 ,0% ,0% ,.0 )'));
+            expect(parse('hsl(0 0% 0% / 0)')).toEqual(parse(' hsla(.0,.0%,.0%,.0%)'));
+            expect(parse('hsl(0 0% 0% / 0)')).toEqual(parse('hsla(  0 ,0% ,0% ,.0 ) '));
 
             expect(parse('hsl(120 100% 25%)')).toEqual([0, 0.5, 0, 1]);
             expect(parse('hsl(120 100% 25%)')).toEqual(parse('hsl(120.0 100.0% 25.0%)'));

--- a/src/util/parse_css_color.ts
+++ b/src/util/parse_css_color.ts
@@ -30,7 +30,7 @@ import {HSLColor, hslToRgb, RGBColor} from './color_spaces';
  * or `undefined` if the input is not a valid color string.
  */
 export function parseCssColor(input: string): RGBColor | undefined {
-    input = input.toLowerCase();
+    input = input.toLowerCase().trim();
 
     if (input === 'transparent') {
         return [0, 0, 0, 0];


### PR DESCRIPTION
Fix for [#2812](https://github.com/maplibre/maplibre-gl-js/issues/2812)

Allow for leading or trailing spaces in css color values.
Treat values like `" rgba(220, 230, 200, 1)"` as valid.


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.