### PR TITLE
Bump version to 19.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## main
+
+## 19.2.2
+
+### ✨ Features and improvements
+
+* Trim css color before parsing [#255](https://github.com/maplibre/maplibre-style-spec/pull/255)
+
 ## 19.2.1
 ### ✨ Features and improvements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
-  "version": "19.2.1",
+  "version": "19.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/maplibre-gl-style-spec",
-      "version": "19.2.1",
+      "version": "19.2.2",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maplibre/maplibre-gl-style-spec",
   "description": "a specification for maplibre styles",
-  "version": "19.2.1",
+  "version": "19.2.2",
   "author": "MapLibre",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
Patch for css color parsing changes.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!