### PR TITLE
Update docs to describe raster-fade-duration's effect on rendering videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main
 
+* Document `raster-fade-duration` property's effect on rendering a video. [#297](https://github.com/maplibre/maplibre-style-spec/pull/297)
+
 ## 19.3.0
 
 ### ✨ Features and improvements

--- a/docs/src/routes/sources/index.tsx
+++ b/docs/src/routes/sources/index.tsx
@@ -16,7 +16,7 @@ function Sources() {
     return (
         <div>
             <Markdown content={`# Sources
-Sources state which data the map should display. Specify the type of source with the \`"type"\` property, which must be one of 
+Sources state which data the map should display. Specify the type of source with the \`"type"\` property, which must be one of
 ${sourceTypes.map((t) => {
             return `\`${t}\``;
         }).join(', ')}. Adding a source isn't enough to make data appear on the map because sources don't contain styling details like color or width. Layers refer to a source and give it a visual representation. This makes it possible to style the same source in different ways, like differentiating between types of roads in a highways layer.
@@ -59,7 +59,7 @@ Tiled sources (vector and raster) must specify their details according to the [T
 ## vector
 
 
-A vector tile source. Tiles must be in [Mapbox Vector Tile format](https://docs.mapbox.com/vector-tiles/). All geometric coordinates in vector tiles must be between \`-1 * extent\` and \`(extent * 2) - 1\` inclusive. All layers that use a vector source must specify a [\`"source-layer"\`](${import.meta.env.BASE_URL}layers/#source-layer) value. 
+A vector tile source. Tiles must be in [Mapbox Vector Tile format](https://docs.mapbox.com/vector-tiles/). All geometric coordinates in vector tiles must be between \`-1 * extent\` and \`(extent * 2) - 1\` inclusive. All layers that use a vector source must specify a [\`"source-layer"\`](${import.meta.env.BASE_URL}layers/#source-layer) value.
 
 \`\`\`json
 "maplibre-streets": {
@@ -233,6 +233,8 @@ The \`"coordinates"\` array contains \`[longitude, latitude]\` pairs for the ima
 A video source. The \`"urls"\` value is an array. For each URL in the array, a video element [source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source) will be created. To support the video across browsers, supply URLs in multiple formats.
 
 The \`"coordinates"\` array contains \`[longitude, latitude]\` pairs for the video corners listed in clockwise order: top left, top right, bottom right, bottom left.
+
+When rendered as a [raster layer](${import.meta.env.BASE_URL}layers/#raster), the layer's [\`raster-fade-duration\`](${import.meta.env.BASE_URL}layers/#paint-raster-raster-fade-duration) property will cause the video to fade in. This happens when playback is started, paused and resumed, or when the video's coordinates are updated. To avoid this behavior, set the layer's [\`raster-fade-duration\`](${import.meta.env.BASE_URL}layers/#paint-raster-raster-fade-duration) property to \`0\`.
 
 \`\`\`json
 "video": {

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -5778,7 +5778,7 @@
       "minimum": 0,
       "transition": false,
       "units": "milliseconds",
-      "doc": "Fade duration when a new tile is added.",
+      "doc": "Fade duration when a new tile is added, or when a video is started or its coordinates are updated.",
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",


### PR DESCRIPTION
Partially addresses the documentation update requested in https://github.com/maplibre/maplibre-gl-js/issues/2922. Will also open a PR in that repo to mention the property in video_source.ts.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
