### PR TITLE
Add isZoomExpression

### DIFF
--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -234,6 +234,10 @@ export class ZoomDependentExpression<Kind extends EvaluationKind> {
     }
 }
 
+export function isZoomExpression(expression: any): expression is ZoomConstantExpression<'source'> | ZoomDependentExpression<'source'> {
+    return (expression as ZoomConstantExpression<'source'>)._styleExpression !== undefined;
+}
+
 export type ConstantExpression = {
     kind: 'constant';
     readonly evaluate: (

--- a/src/style-spec.ts
+++ b/src/style-spec.ts
@@ -76,7 +76,7 @@ import derefLayers from './deref';
 import diff, {operations} from './diff';
 import ValidationError from './error/validation_error';
 import ParsingError from './error/parsing_error';
-import {FeatureState, StyleExpression, isExpression, createExpression, createPropertyExpression, normalizePropertyExpression, ZoomConstantExpression, ZoomDependentExpression, StylePropertyFunction, Feature, GlobalProperties, SourceExpression, CompositeExpression, StylePropertyExpression} from './expression';
+import {FeatureState, StyleExpression, isExpression, isZoomExpression, createExpression, createPropertyExpression, normalizePropertyExpression, ZoomConstantExpression, ZoomDependentExpression, StylePropertyFunction, Feature, GlobalProperties, SourceExpression, CompositeExpression, StylePropertyExpression} from './expression';
 import featureFilter, {isExpressionFilter} from './feature_filter';
 
 import convertFilter from './feature_filter/convert';
@@ -117,6 +117,7 @@ const expression = {
     createPropertyExpression,
     isExpression,
     isExpressionFilter,
+    isZoomExpression,
     normalizePropertyExpression,
 };
 


### PR DESCRIPTION
Addresses #267 

In https://github.com/maplibre/maplibre-gl-js/pull/2837, we need a way of checking if a given `expression` is a `ZoomConstantExpression`, and then casting it as such. In this PR, we expose an `isZoomExpression` type guard.

Note: I'm not sure if I'm meant to post a PR where I integrate a staged version of maplibre-style-spec into maplibre-gl-gs?

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
