### PR TITLE
Add raster-dem encoding parameters to RasterDEMSourceSpecification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Document `raster-fade-duration` property's effect on rendering a video. [#297](https://github.com/maplibre/maplibre-style-spec/pull/297)
 * Add and expose `isZoomExpression`. [#267](https://github.com/maplibre/maplibre-style-spec/issues/267)
-* Add raster dem source `redMix`, `greenMix`, `blueMix`, `baseMix` properties [#326](https://github.com/maplibre/maplibre-style-spec/issues/326)
+* Add raster dem source `redFactor`, `greenFactor`, `blueFactor`, `baseShift` properties [#326](https://github.com/maplibre/maplibre-style-spec/issues/326)
 
 ## 19.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Document `raster-fade-duration` property's effect on rendering a video. [#297](https://github.com/maplibre/maplibre-style-spec/pull/297)
 * Add and expose `isZoomExpression`. [#267](https://github.com/maplibre/maplibre-style-spec/issues/267)
+* Add raster dem source `redMix`, `greenMix`, `blueMix`, `baseMix` properties [#326](https://github.com/maplibre/maplibre-style-spec/issues/326)
 
 ## 19.3.0
 

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -621,7 +621,7 @@
           }
         },
         "hillshade": {
-          "doc": "Client-side hillshading visualization based on DEM data. Currently, the implementation only supports Mapbox Terrain RGB and Mapzen Terrarium tiles.",
+          "doc": "Client-side hillshading visualization based on DEM data. The implementation supports Mapbox Terrain RGB, Mapzen Terrarium tiles and custom encodings.",
           "sdk-support": {
             "basic functionality": {
               "js": "0.43.0",

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -354,28 +354,28 @@
           "doc": "Mapbox Terrain RGB tiles. See https://www.mapbox.com/help/access-elevation-data/#mapbox-terrain-rgb for more info."
         },
         "custom": {
-          "doc": "Decodes tiles using the redMix, blueMix, greenMix, baseMix parameters."
+          "doc": "Decodes tiles using the redFactor, blueFactor, greenFactor, baseShift parameters."
         }
       },
       "default": "mapbox",
       "doc": "The encoding used by this source. Mapbox Terrain RGB is used by default."
     },
-    "redMix": {
+    "redFactor": {
       "type": "number",
       "default": 1.0,
       "doc": "Value that will be multiplied by the red channel value when decoding. Only used on custom encodings."
     },
-    "blueMix": {
+    "blueFactor": {
       "type": "number",
       "default": 1.0,
       "doc": "Value that will be multiplied by the blue channel value when decoding. Only used on custom encodings."
     },
-    "greenMix": {
+    "greenFactor": {
       "type": "number",
       "default": 1.0,
       "doc": "Value that will be multiplied by the green channel value when decoding. Only used on custom encodings."
     },   
-    "baseMix": {
+    "baseShift": {
       "type": "number",
       "default": 0.0,
       "doc": "Value that will be added to the encoding mix when decoding. Only used on custom encodings."

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -352,11 +352,34 @@
         },
         "mapbox": {
           "doc": "Mapbox Terrain RGB tiles. See https://www.mapbox.com/help/access-elevation-data/#mapbox-terrain-rgb for more info."
+        },
+        "custom": {
+          "doc": "Decodes tiles using the redMix, blueMix, greenMix, baseMix parameters."
         }
       },
       "default": "mapbox",
-      "doc": "The encoding used by this source. Mapbox Terrain RGB is used by default"
+      "doc": "The encoding used by this source. Mapbox Terrain RGB is used by default."
     },
+    "redMix": {
+      "type": "number",
+      "default": 1.0,
+      "doc": "Value that will be multiplied by the red channel value when decoding. Only used on custom encodings."
+    },
+    "blueMix": {
+      "type": "number",
+      "default": 1.0,
+      "doc": "Value that will be multiplied by the blue channel value when decoding. Only used on custom encodings."
+    },
+    "greenMix": {
+      "type": "number",
+      "default": 1.0,
+      "doc": "Value that will be multiplied by the green channel value when decoding. Only used on custom encodings."
+    },   
+    "baseMix": {
+      "type": "number",
+      "default": 0.0,
+      "doc": "Value that will be added to the encoding mix when decoding. Only used on custom encodings."
+    },    
     "volatile": {
       "type": "boolean",
       "default": false,

--- a/src/validate/validate.ts
+++ b/src/validate/validate.ts
@@ -24,7 +24,6 @@ import validateImage from './validate_image';
 import validatePadding from './validate_padding';
 import validateVariableAnchorOffsetCollection from './validate_variable_anchor_offset_collection';
 import validateSprite from './validate_sprite';
-import validateRasterDEMSource from './validate_raster_dem_source';
 
 const VALIDATORS = {
     '*'() {
@@ -49,7 +48,6 @@ const VALIDATORS = {
     'padding': validatePadding,
     'variableAnchorOffsetCollection': validateVariableAnchorOffsetCollection,
     'sprite': validateSprite,
-    'source_raster_dem': validateRasterDEMSource
 };
 
 // Main recursive validation function. Tracks:

--- a/src/validate/validate.ts
+++ b/src/validate/validate.ts
@@ -24,6 +24,7 @@ import validateImage from './validate_image';
 import validatePadding from './validate_padding';
 import validateVariableAnchorOffsetCollection from './validate_variable_anchor_offset_collection';
 import validateSprite from './validate_sprite';
+import validateRasterDEMSource from './validate_raster_dem_source';
 
 const VALIDATORS = {
     '*'() {
@@ -48,6 +49,7 @@ const VALIDATORS = {
     'padding': validatePadding,
     'variableAnchorOffsetCollection': validateVariableAnchorOffsetCollection,
     'sprite': validateSprite,
+    'source_raster_dem': validateRasterDEMSource
 };
 
 // Main recursive validation function. Tracks:

--- a/src/validate/validate_raster_dem_source.test.ts
+++ b/src/validate/validate_raster_dem_source.test.ts
@@ -1,0 +1,54 @@
+import validateSpec from './validate';
+import v8 from '../reference/v8.json' assert {type: 'json'};
+import validateRasterDEMSource from './validate_raster_dem_source';
+
+function checkErrorMessage(message: string, key: string, expectedType: string, foundType: string) {
+    expect(message).toContain(key);
+    expect(message).toContain(expectedType);
+    expect(message).toContain(foundType);
+}
+
+describe('Validate source_raster_dem', () => {
+    test('Should return error in case of unknown property', () => {
+        const errors = validateRasterDEMSource({validateSpec, value: {a: 1} as any, styleSpec: v8, style: {} as any});
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toContain('a');
+        expect(errors[0].message).toContain('unknown');
+    });
+
+    test('Should return errors according to spec violations', () => {
+        const errors = validateRasterDEMSource({validateSpec, value: {type: 'raster-dem', url: {} as any, tiles: {} as any, encoding: 'foo' as any}, styleSpec: v8, style: {} as any});
+        expect(errors).toHaveLength(3);
+        checkErrorMessage(errors[0].message, 'url', 'string', 'object');
+        checkErrorMessage(errors[1].message, 'tiles', 'array', 'object');
+        checkErrorMessage(errors[2].message, 'encoding', '[terrarium, mapbox, custom]', 'foo');
+    });
+
+    test('Should return errors when custom encoding values are set but encoding is "mapbox"', () => {
+        const errors = validateRasterDEMSource({validateSpec, value: {type: 'raster-dem', encoding: 'mapbox', 'redFactor': 1.0, 'greenFactor': 1.0, 'blueFactor': 1.0, 'baseShift': 1.0}, styleSpec: v8, style: {} as any});
+        expect(errors).toHaveLength(4);
+        checkErrorMessage(errors[0].message, 'redFactor', 'custom', 'mapbox');
+        checkErrorMessage(errors[1].message, 'greenFactor', 'custom', 'mapbox');
+        checkErrorMessage(errors[2].message, 'blueFactor', 'custom', 'mapbox');
+        checkErrorMessage(errors[3].message, 'baseShift', 'custom', 'mapbox');
+    });
+
+    test('Should return errors when custom encoding values are set but encoding is "terrarium"', () => {
+        const errors = validateRasterDEMSource({validateSpec, value: {type: 'raster-dem', encoding: 'terrarium', 'redFactor': 1.0, 'greenFactor': 1.0, 'blueFactor': 1.0, 'baseShift': 1.0}, styleSpec: v8, style: {} as any});
+        expect(errors).toHaveLength(4);
+        checkErrorMessage(errors[0].message, 'redFactor', 'custom', 'terrarium');
+        checkErrorMessage(errors[1].message, 'greenFactor', 'custom', 'terrarium');
+        checkErrorMessage(errors[2].message, 'blueFactor', 'custom', 'terrarium');
+        checkErrorMessage(errors[3].message, 'baseShift', 'custom', 'terrarium');
+    });
+
+    test('Should pass when custom encoding values are set and encoding is "custom"', () => {
+        const errors = validateRasterDEMSource({validateSpec, value: {type: 'raster-dem', encoding: 'custom', 'redFactor': 1.0, 'greenFactor': 1.0, 'blueFactor': 1.0, 'baseShift': 1.0}, styleSpec: v8, style: {} as any});
+        expect(errors).toHaveLength(0);
+    });
+
+    test('Should pass if everything is according to spec', () => {
+        const errors = validateRasterDEMSource({validateSpec, value: {type: 'raster-dem'}, styleSpec: v8, style: {} as any});
+        expect(errors).toHaveLength(0);
+    });
+});

--- a/src/validate/validate_raster_dem_source.test.ts
+++ b/src/validate/validate_raster_dem_source.test.ts
@@ -1,6 +1,7 @@
 import validateSpec from './validate';
 import v8 from '../reference/v8.json' assert {type: 'json'};
 import validateRasterDEMSource from './validate_raster_dem_source';
+import {RasterDEMSourceSpecification} from '../types.g';
 
 function checkErrorMessage(message: string, key: string, expectedType: string, foundType: string) {
     expect(message).toContain(key);
@@ -9,6 +10,18 @@ function checkErrorMessage(message: string, key: string, expectedType: string, f
 }
 
 describe('Validate source_raster_dem', () => {
+    test('Should pass when value is undefined', () => {
+        const errors = validateRasterDEMSource({validateSpec, value: undefined, styleSpec: v8, style: {} as any});
+        expect(errors).toHaveLength(0);
+    });
+
+    test('Should return error when value is not an object', () => {
+        const errors = validateRasterDEMSource({validateSpec, value: '' as unknown as RasterDEMSourceSpecification, styleSpec: v8, style: {} as any});
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toContain('object');
+        expect(errors[0].message).toContain('expected');
+    });
+
     test('Should return error in case of unknown property', () => {
         const errors = validateRasterDEMSource({validateSpec, value: {a: 1} as any, styleSpec: v8, style: {} as any});
         expect(errors).toHaveLength(1);

--- a/src/validate/validate_raster_dem_source.ts
+++ b/src/validate/validate_raster_dem_source.ts
@@ -1,0 +1,53 @@
+import ValidationError from '../error/validation_error';
+import getType from '../util/get_type';
+import type {RasterDEMSourceSpecification, StyleSpecification} from '../types.g';
+import v8 from '../reference/v8.json' assert {type: 'json'};
+
+interface ValidateRasterDENSourceOptions {
+    value: RasterDEMSourceSpecification;
+    styleSpec: typeof v8;
+    style: StyleSpecification;
+    validateSpec: Function;
+}
+
+export default function validateRasterDEMSource(
+    options: ValidateRasterDENSourceOptions
+): ValidationError[] {
+
+    const rasterDEM = options.value;
+    const styleSpec = options.styleSpec;
+    const rasterDEMSpec = styleSpec.source_raster_dem;
+    const style = options.style;
+
+    let errors = [];
+
+    const rootType = getType(rasterDEM);
+    if (rasterDEM === undefined) {
+        return errors;
+    } else if (rootType !== 'object') {
+        errors.push(new ValidationError('source_raster_dem', rasterDEM, `object expected, ${rootType} found`));
+        return errors;
+    }
+
+    const isCustomEncoding = options.value.encoding === 'custom';
+    const customEncodingKeys = ['redFactor', 'greenFactor', 'blueFactor', 'baseShift'];
+
+    for (const key in rasterDEM) {
+        if (!isCustomEncoding && customEncodingKeys.includes(key)) {
+            errors.push(new ValidationError(key, rasterDEM[key], `"${key}" is only valid when "encoding" is set to "custom". ${options.value.encoding} encoding found`));
+        } else if (rasterDEMSpec[key]) {
+            errors = errors.concat(options.validateSpec({
+                key,
+                value: rasterDEM[key],
+                valueSpec: rasterDEMSpec[key],
+                validateSpec: options.validateSpec,
+                style,
+                styleSpec
+            }));
+        } else {
+            errors.push(new ValidationError(key, rasterDEM[key], `unknown property "${key}"`));
+        }
+    }
+
+    return errors;
+}

--- a/src/validate/validate_source.ts
+++ b/src/validate/validate_source.ts
@@ -6,6 +6,7 @@ import validateEnum from './validate_enum';
 import validateExpression from './validate_expression';
 import validateString from './validate_string';
 import getType from '../util/get_type';
+import validateRasterDEMSource from './validate_raster_dem_source';
 
 const objectElementValidators = {
     promoteId: validatePromoteId
@@ -28,7 +29,6 @@ export default function validateSource(options) {
     switch (type) {
         case 'vector':
         case 'raster':
-        case 'raster-dem':
             errors = validateObject({
                 key,
                 value,
@@ -36,6 +36,15 @@ export default function validateSource(options) {
                 style: options.style,
                 styleSpec,
                 objectElementValidators,
+                validateSpec,
+            });
+            return errors;
+        case 'raster-dem':
+            errors = validateRasterDEMSource({
+                sourceName: key,
+                value,
+                style: options.style,
+                styleSpec,
                 validateSpec,
             });
             return errors;


### PR DESCRIPTION
Following #326 this PR adds `redMix`, `blueMix`, `greenMix` and `baseMix` parameters to `RasterDEMSourceSpecification`

See [this](https://github.com/maplibre/maplibre-gl-js/pull/3087) PR on the maplibre-gl-js repo for the other part of the implementation

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
