### PR TITLE
Improve hillshade layers not using raster-dem sources error message

### DIFF
--- a/src/validate/validate_layer.ts
+++ b/src/validate/validate_layer.ts
@@ -61,6 +61,8 @@ export default function validateLayer(options) {
                 errors.push(new ValidationError(key, layer.source, `source "${layer.source}" not found`));
             } else if (sourceType === 'vector' && type === 'raster') {
                 errors.push(new ValidationError(key, layer.source, `layer "${layer.id}" requires a raster source`));
+            } else if (sourceType !== 'raster-dem' && type === 'hillshade') {
+                errors.push(new ValidationError(key, layer.source, `layer "${layer.id}" requires a raster-dem source`));
             } else if (sourceType === 'raster' && type !== 'raster') {
                 errors.push(new ValidationError(key, layer.source, `layer "${layer.id}" requires a vector source`));
             } else if (sourceType === 'vector' && !layer['source-layer']) {

--- a/test/integration/style-spec/tests/layers.input.json
+++ b/test/integration/style-spec/tests/layers.input.json
@@ -9,6 +9,10 @@
       "type": "raster",
       "url": "https://demotiles.maplibre.org/terrain-tiles/tiles.json"
     },
+    "raster-dem": {
+      "type": "raster-dem",
+      "url": "https://demotiles.maplibre.org/terrain-tiles/tiles.json"
+    },
     "geojson": {
       "type": "geojson",
       "data": {}
@@ -71,6 +75,24 @@
       "id": "raster-vector-mismatch",
       "type": "raster",
       "source": "vector",
+      "source-layer": "source-layer"
+    },
+    {
+      "id": "raster-hillshade-mismatch",
+      "type": "hillshade",
+      "source": "raster",
+      "source-layer": "source-layer"
+    },
+    {
+      "id": "vector-hillshade-mismatch",
+      "type": "hillshade",
+      "source": "vector",
+      "source-layer": "source-layer"
+    },
+    {
+      "id": "raster-dem-raster-mismatch",
+      "type": "raster",
+      "source": "raster-dem",
       "source-layer": "source-layer"
     },
     {

--- a/test/integration/style-spec/tests/layers.output.json
+++ b/test/integration/style-spec/tests/layers.output.json
@@ -1,78 +1,90 @@
 [
   {
     "message": "layers[0]: either \"type\" or \"ref\" is required",
-    "line": 23
+    "line": 27
   },
   {
     "message": "layers[1]: missing required property \"id\"",
-    "line": 28
+    "line": 32
   },
   {
     "message": "layers[3]: \"type\" is prohibited for ref layers",
-    "line": 42
-  },
-  {
-    "message": "layers[3]: \"source\" is prohibited for ref layers",
-    "line": 43
-  },
-  {
-    "message": "layers[3]: \"source-layer\" is prohibited for ref layers",
-    "line": 44
-  },
-  {
-    "message": "layers[3]: \"filter\" is prohibited for ref layers",
-    "line": 45
-  },
-  {
-    "message": "layers[3]: \"layout\" is prohibited for ref layers",
     "line": 46
   },
   {
-    "message": "layers[4]: ref layer \"not-found\" not found",
+    "message": "layers[3]: \"source\" is prohibited for ref layers",
+    "line": 47
+  },
+  {
+    "message": "layers[3]: \"source-layer\" is prohibited for ref layers",
+    "line": 48
+  },
+  {
+    "message": "layers[3]: \"filter\" is prohibited for ref layers",
+    "line": 49
+  },
+  {
+    "message": "layers[3]: \"layout\" is prohibited for ref layers",
     "line": 50
   },
   {
-    "message": "layers[5]: ref cannot reference another ref layer",
+    "message": "layers[4]: ref layer \"not-found\" not found",
     "line": 54
   },
   {
+    "message": "layers[5]: ref cannot reference another ref layer",
+    "line": 58
+  },
+  {
     "message": "layers[6]: missing required property \"source\"",
-    "line": 56
+    "line": 60
   },
   {
     "message": "layers[7]: source \"not-found\" not found",
-    "line": 63
+    "line": 67
   },
   {
     "message": "layers[8]: layer \"vector-raster-mismatch\" requires a vector source",
-    "line": 68
+    "line": 72
   },
   {
     "message": "layers[9]: layer \"raster-vector-mismatch\" requires a raster source",
-    "line": 73
+    "line": 77
   },
   {
-    "message": "layers[11]: duplicate layer id \"duplicate\", previously used at line 77",
+    "message": "layers[10]: layer \"raster-hillshade-mismatch\" requires a raster-dem source",
     "line": 83
   },
   {
-    "message": "layers[12].type: expected one of [fill, line, symbol, circle, heatmap, fill-extrusion, raster, hillshade, background], \"invalid\" found",
-    "line": 90
+    "message": "layers[11]: layer \"vector-hillshade-mismatch\" requires a raster-dem source",
+    "line": 89
   },
   {
-    "message": "layers[13]: layer \"missing-source-layer\" must specify a \"source-layer\"",
-    "line": 100
+    "message": "layers[12]: raster-dem source can only be used with layer type 'hillshade'.",
+    "line": 95
   },
   {
-    "message": "layers[15]: layer \"line-gradient-bad\" specifies a line-gradient, which requires a GeoJSON source with `lineMetrics` enabled.",
+    "message": "layers[14]: duplicate layer id \"duplicate\", previously used at line 99",
+    "line": 105
+  },
+  {
+    "message": "layers[15].type: expected one of [fill, line, symbol, circle, heatmap, fill-extrusion, raster, hillshade, background], \"invalid\" found",
     "line": 112
   },
   {
-    "message": "layers[16]: layer \"line-gradient-missing-lineMetrics\" specifies a line-gradient, which requires a GeoJSON source with `lineMetrics` enabled.",
-    "line": 126
+    "message": "layers[16]: layer \"missing-source-layer\" must specify a \"source-layer\"",
+    "line": 122
   },
   {
-    "message": "layers[18].type: expected one of [fill, line, symbol, circle, heatmap, fill-extrusion, raster, hillshade, background], \"custom\" found",
-    "line": 156
+    "message": "layers[18]: layer \"line-gradient-bad\" specifies a line-gradient, which requires a GeoJSON source with `lineMetrics` enabled.",
+    "line": 134
+  },
+  {
+    "message": "layers[19]: layer \"line-gradient-missing-lineMetrics\" specifies a line-gradient, which requires a GeoJSON source with `lineMetrics` enabled.",
+    "line": 148
+  },
+  {
+    "message": "layers[21].type: expected one of [fill, line, symbol, circle, heatmap, fill-extrusion, raster, hillshade, background], \"custom\" found",
+    "line": 178
   }
 ]


### PR DESCRIPTION
This PR improves the errors around adding `hillshade` layers that don't use a `raster-dem` source.

Before this PR, adding a `hillshade` layer with a `raster` source said `layer \"test\" requires a vector source"` which is not right.
With this PR, the same use case results in the following error: `layer \"test\" requires a raster-dem source`.
It also adds a couple of tests to check that and an extra one that tests a condition that was not met before (using a `raster-dem` source type on layers that are not `hillshade`)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
