### PR TITLE
Remove <!-- copyeditor --> comment from rendered docs

### DIFF
--- a/docs/src/routes/sprite/index.tsx
+++ b/docs/src/routes/sprite/index.tsx
@@ -36,7 +36,7 @@ A valid sprite source must supply two types of files:
 - _Image files_, which are PNG images containing the sprite data.
 
 Apart from the required \`width\`, \`height\`, \`x\`, and \`y\` properties, the following optional properties are supported:
-<!-- copyeditor ignore retext-passive -->
+
 - \`content\`: An array of four numbers, with the first two specifying the left, top corner, and the last two specifying the right, bottom corner. If present, and if the icon uses [\`icon-text-fit\`](${import.meta.env.BASE_URL}layers/#layout-symbol-icon-text-fit), the symbol's text will be fit inside the content box.
 - \`stretchX\`: An array of two-element arrays, consisting of two numbers that represent the _from_ position and the _to_ position of areas that can be stretched.
 - \`stretchY\`: Same as \`stretchX\`, but for the vertical dimension.


### PR DESCRIPTION
Currently, on the [Sprite page of the Maplibre Style Spec docs](https://maplibre.org/maplibre-style-spec/sprite/), an HTML comment is being rendered as text:

![](https://github.com/maplibre/maplibre-style-spec/assets/48392/d10a999d-6727-4dd1-b234-fa7d10d5c78a)

When the Markdown is rendered as HTML the `<` in `<!-- copyeditor ignore retext-passive -->` is being escaped as `&lt;` and so the comment is appearing in the docs. The comment is probably some leftover debris from when https://npm.io/package/@mapbox/copyeditor was being used (pre-fork?). It's the only instance of a `<!-- copyeditor -->` comment in the docs, and so it seems the safest/easiest thing to do is simply remove it.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
