### PR TITLE
Add documentation on the sprite index file's optional sdf property 

### DIFF
--- a/docs/src/routes/sprite/index.tsx
+++ b/docs/src/routes/sprite/index.tsx
@@ -40,6 +40,7 @@ Apart from the required \`width\`, \`height\`, \`x\`, and \`y\` properties, the 
 - \`content\`: An array of four numbers, with the first two specifying the left, top corner, and the last two specifying the right, bottom corner. If present, and if the icon uses [\`icon-text-fit\`](${import.meta.env.BASE_URL}layers/#layout-symbol-icon-text-fit), the symbol's text will be fit inside the content box.
 - \`stretchX\`: An array of two-element arrays, consisting of two numbers that represent the _from_ position and the _to_ position of areas that can be stretched.
 - \`stretchY\`: Same as \`stretchX\`, but for the vertical dimension.
+- \`sdf\`: Boolean. If \`true\` then the image is handled as a signed-distance field (SDF) and its color can be set at runtime using the [\`icon-color\`](${import.meta.env.BASE_URL}layers/#paint-symbol-icon-color) and [\`icon-halo-color\`](${import.meta.env.BASE_URL}layers/#paint-symbol-icon-halo-color) properties. Defaults to \`false\`.
 
 MapLibre SDKs will use the value of the \`sprite\` property in the style to generate the URLs for loading both files. First, for both file types, it will append \`@2x\` to the URL on high-DPI devices. Second, it will append a file extension: \`.json\` for the index file, and \`.png\` for the image file. For example, if you specified \`"sprite": "https://example.com/sprite"\`, renderers would load \`https://example.com/sprite.json\` and \`https://example.com/sprite.png\`, or \`https://example.com/sprite@2x.json\` and \`https://example.com/sprite@2x.png\`.
 

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -5208,7 +5208,7 @@
       "type": "color",
       "default": "#000000",
       "transition": true,
-      "doc": "The color of the icon. This can only be used with sdf icons.",
+      "doc": "The color of the icon. This can only be used with SDF icons.",
       "requires": [
         "icon-image"
       ],


### PR DESCRIPTION
SDF icons have always been an unloved corner of the style spec — Mapbox even considered removing them back in 2016 (see https://github.com/mapbox/mapbox-gl-style-spec/issues/444). But Maplibre has cross-platform support for them, and `sdf` is the only one of the nine sprite index properties that isn't documented.

I've added a description of the `sdf` property and how it enables the use of the `icon-color` and `icon-halo-color` style spec properties. I've also made a teeny-tiny change to `v8.json` to upper-case "SDF" in the description of the `icon-color` property, but it makes no material change to the style spec itself.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
