### PR TITLE
Change default font-face to Noto Sans Regular [#311]

### DIFF
--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -1823,8 +1823,7 @@
       "type": "array",
       "value": "string",
       "default": [
-        "Open Sans Regular",
-        "Arial Unicode MS Regular"
+        "Noto Sans Regular"
       ],
       "doc": "Font stack to use for displaying text.",
       "requires": [


### PR DESCRIPTION
* Change it from Open Sans Regular, Arial Unicode MS Regular which does not have a freely licensed reproducible build.

See https://github.com/maplibre/maplibre-style-spec/issues/311 for discussion.

I don't think that this change is high priority, I'd be fine with keeping the current defaults indefinitely. The consensus seems to be that this default should nearly never be used anyways. 

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Document any changes to public APIs.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
