### PR TITLE
Fix node version to use from nvmrc file

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version-file: '.nvmrc'
 
     - name: Install NPM packages
       run: npm ci

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version-file: '.nvmrc'
 
     - name: Install NPM packages
       run: npm ci

--- a/.github/workflows/publish-style-spec.yml
+++ b/.github/workflows/publish-style-spec.yml
@@ -12,11 +12,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js 18 x64
+      - name: Use Node.js from nvmrc
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: 18
-          architecture: x64
+          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Get version

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version-file: '.nvmrc'
       - run: npm ci
       - run: npm run jest-ci -- --coverage --coverageDirectory=coverage-unit --coverageReporters json --selectProjects unit
       - run: npm run jest-ci -- --coverage --coverageDirectory=coverage-integration --coverageReporters json --selectProjects integration

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version-file: '.nvmrc'
       - run: npm ci
       - run: npm run lint
         if: success() || failure()
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version-file: '.nvmrc'
       - run: npm ci
       - run: npm run generate-style-spec
       - run: npm run generate-typings


### PR DESCRIPTION
This fixes the issue with CI where it took a node version that is not tested to work (using lts - i.e 20).