### PR TITLE
Streamline publish process

### DIFF
--- a/.github/workflows/create-bumb-version-pr.yml
+++ b/.github/workflows/create-bumb-version-pr.yml
@@ -1,0 +1,40 @@
+name: Create bump version PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to change to.
+        required: true
+        type: string
+
+jobs:
+  bump-version-pr:
+    name: Bump version PR
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Use Node.js from nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Bump version
+        run: |
+          npm version --commit-hooks false --git-tag-version false ${{ inputs.version }}
+          ./build/bump-version-changelog.js ${{ inputs.version }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: Bump version to ${{ inputs.version }}
+          branch: bump-version-to-${{ inputs.version }}
+          title: Bump version to ${{ inputs.version }}

--- a/.github/workflows/publish-style-spec.yml
+++ b/.github/workflows/publish-style-spec.yml
@@ -1,11 +1,47 @@
 name: publish-style-spec
 
 on:
-  workflow_dispatch
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
-  build_publish:
+  release-check:
+    name: Check if version changed
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Use Node.js from nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Check if version changed
+        id: check
+        run: |
+          latestNpmPackageVersion=$( npm view maplibre-gl versions --json | jq '.[-1]' -r )
+          currentVersion=$( node -e "console.log(require('./package.json').version)" )
+          if [ "$latestNpmPackageVersion" == "$currentVersion" ]; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+          
+    outputs:
+      publish: ${{ steps.check.outputs.changed }}
+
+
+  publish:
     name: Build, publish
+    needs: release-check
+    if: ${{ needs.release-check.outputs.publish == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,10 @@ npm run test-build
 npm run test-integration
 npm run test-unit
 ```
+
+# Publish style-spec NPM package
+In order to publish the package to NPM:
+1. Go to "Action" in GitHub
+2. Run the create bump version PR action to create a PR with the version bump
+3. Approve and merge this PR after you have reviewed the Changelog file
+4. Squash and merge the PR, an automatic action will pick up the change and publish the package to npm

--- a/build/bump-version-changelog.js
+++ b/build/bump-version-changelog.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+/**
+ * This script updates the changelog.md file with the version given in the arguments
+ * It replaces ## main with ## <version>
+ * Removes _...Add new stuff here..._
+ * And adds on top a ## main with add stuff here.
+ */
+
+import * as fs from 'fs';
+
+const changelogPath = 'CHANGELOG.md';
+let changelog = fs.readFileSync(changelogPath, 'utf8');
+changelog = changelog.replace('## main', `## ${process.argv[2]}`);
+changelog = changelog.replaceAll('- _...Add new stuff here..._\n', '');
+changelog = `## main
+
+### ✨ Features and improvements
+- _...Add new stuff here..._
+
+### 🐞 Bug fixes
+- _...Add new stuff here..._
+
+` + changelog;
+
+fs.writeFileSync(changelogPath, changelog, 'utf8');


### PR DESCRIPTION
## Launch Checklist

This aligns the build process with maplibre-gl where you open a PR with a version bump and then the package is published automatically after this PR is merged to main branch.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
