### PR TITLE
Adds the missing methods back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main
 
+* Add back `migrate`, `validate` and `format` to the exported methods of this package
 * Add terrain to diff method and improve type. This also removes the `operations` from the API [#460](https://github.com/maplibre/maplibre-style-spec/pull/460)
 
 ## 19.3.3

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,9 @@ import FormatExpression from './expression/definitions/format';
 import Literal from './expression/definitions/literal';
 import CompoundExpression from './expression/compound_expression';
 import {VariableAnchorOffsetCollectionSpecification} from './types.g';
+import format from './format';
+import validate from './validate/validate';
+import migrate from './migrate';
 
 const expression = {
     StyleExpression,
@@ -181,6 +184,9 @@ export {
     featureFilter,
     typeOf,
     toString,
+    format,
+    validate,
+    migrate,
 
     ColorType,
     interpolates,


### PR DESCRIPTION
## Launch Checklist

Fixes #24 by adding `format`, `migrate` and `validate`.
 - #24
I have tested the outcome of adding this to maplibre-gl, looking at the dev build with treehsaking set to true, and I didn't see these method included.
I'm not sure about the original behavior, but I don't think I see it now.
In any case, these are needed for other packages and needs to be included.


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
