### PR TITLE
restore export of operations object

### DIFF
--- a/src/diff.ts
+++ b/src/diff.ts
@@ -31,6 +31,29 @@ export type DiffOperationsMap = {
 
 export type DiffOperations = keyof DiffOperationsMap;
 
+const operations: Record<DiffOperations, string> = {
+    'setStyle': 'setStyle',
+    'addLayer': 'addLayer',
+    'removeLayer': 'removeLayer',
+    'setPaintProperty': 'setPaintProperty',
+    'setLayoutProperty': 'setLayoutProperty',
+    'setFilter': 'setFilter',
+    'addSource': 'addSource',
+    'removeSource': 'removeSource',
+    'setGeoJSONSourceData': 'setGeoJSONSourceData',
+    'setLayerZoomRange': 'setLayerZoomRange',
+    'setLayerProperty': 'setLayerProperty',
+    'setCenter': 'setCenter',
+    'setZoom': 'setZoom',
+    'setBearing': 'setBearing',
+    'setPitch': 'setPitch',
+    'setSprite': 'setSprite',
+    'setGlyphs': 'setGlyphs',
+    'setTransition': 'setTransition',
+    'setLight': 'setLight',
+    'setTerrain': 'setTerrain'
+};
+
 export type DiffCommand<T extends DiffOperations> = {
     command: T;
     args: DiffOperationsMap[T];
@@ -340,3 +363,5 @@ function diffStyles(before: StyleSpecification, after: StyleSpecification): Diff
 }
 
 export default diffStyles;
+
+export {operations};

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ import v8Spec from './reference/v8.json' assert {type: 'json'};
 const v8 = v8Spec as any;
 import latest from './reference/latest';
 import derefLayers from './deref';
-import diff from './diff';
+import diff, {operations} from './diff';
 import ValidationError from './error/validation_error';
 import ParsingError from './error/parsing_error';
 import {FeatureState, StyleExpression, isExpression, isZoomExpression, createExpression, createPropertyExpression, normalizePropertyExpression, ZoomConstantExpression, ZoomDependentExpression, StylePropertyFunction, Feature, GlobalProperties, SourceExpression, CompositeExpression, StylePropertyExpression} from './expression';
@@ -163,7 +163,6 @@ export {
     StylePropertyExpression,
     ZoomDependentExpression,
     FormatExpression,
-
     latest,
 
     interpolateFactory,
@@ -175,6 +174,7 @@ export {
     isExpression,
     isZoomExpression,
     diff,
+    operations,
     supportsPropertyExpression,
     convertFunction,
     createExpression,


### PR DESCRIPTION
Fixes https://github.com/maplibre/maplibre-style-spec/issues/474

Recently **operations** object was removed from style-spec code but it's still imported by maplibre-gl-js.
Here I restore this object to its shape before commit https://github.com/maplibre/maplibre-style-spec/commit/9eaffbd37e1acd53c79a96818dcf6f4c8f2aba62.

Now all the operations' keys are hardcoded twice. I don't know how to do it DRY. But at least now TS will force you to keep the operations object's keys in sync with the interface.