### PR TITLE
fix querying within feature collection of polygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Improve the type of `data` in the `GeoJSONSourceSpecification` for TypeScript [#463](https://github.com/maplibre/maplibre-style-spec/pull/463).
 * Add expression tests to this repo [#476](https://github.com/maplibre/maplibre-style-spec/pull/476)
 
+### 🐞 Bug fixes
+
+- Fix queryRenderedFeatures Within a FeatureCollection of polygons [#477](https://github.com/maplibre/maplibre-style-spec/pull/477)
+
 ## 19.3.3
 
 ### ✨ Features and improvements

--- a/src/expression/definitions/within.ts
+++ b/src/expression/definitions/within.ts
@@ -295,12 +295,24 @@ class Within implements Expression {
         if (isValue(args[1])) {
             const geojson = (args[1] as any);
             if (geojson.type === 'FeatureCollection') {
+                const polygonsCoords = [];
                 for (let i = 0; i < geojson.features.length; ++i) {
-                    const type = geojson.features[i].geometry.type;
-                    if (type === 'Polygon' || type === 'MultiPolygon') {
-                        return new Within(geojson, geojson.features[i].geometry);
+                    const {type, coordinates} = geojson.features[i].geometry;
+                    if (type === 'Polygon') {
+                        polygonsCoords.push(coordinates);
+                    }
+                    if (type === 'MultiPolygon') {
+                        polygonsCoords.push(...coordinates);
                     }
                 }
+                if (polygonsCoords.length) {
+                    const multipolygonWrapper: GeoJSON.MultiPolygon = {
+                        type: 'MultiPolygon',
+                        coordinates: polygonsCoords
+                    };
+                    return new Within(geojson, multipolygonWrapper);
+                }
+
             } else if (geojson.type === 'Feature') {
                 const type = geojson.geometry.type;
                 if (type === 'Polygon' || type === 'MultiPolygon') {

--- a/src/expression/definitions/within.ts
+++ b/src/expression/definitions/within.ts
@@ -5,6 +5,7 @@ import type {Expression} from '../expression';
 import type ParsingContext from '../parsing_context';
 import type EvaluationContext from '../evaluation_context';
 import {ICanonicalTileID} from '../../tiles_and_coordinates';
+import {Position} from 'geojson';
 
 type GeoJSONPolygons = GeoJSON.Polygon | GeoJSON.MultiPolygon;
 
@@ -295,9 +296,9 @@ class Within implements Expression {
         if (isValue(args[1])) {
             const geojson = (args[1] as any);
             if (geojson.type === 'FeatureCollection') {
-                const polygonsCoords = [];
-                for (let i = 0; i < geojson.features.length; ++i) {
-                    const {type, coordinates} = geojson.features[i].geometry;
+                const polygonsCoords: Position[][][] = [];
+                for (const polygon of geojson.features) {
+                    const {type, coordinates} = polygon.geometry;
                     if (type === 'Polygon') {
                         polygonsCoords.push(coordinates);
                     }

--- a/test/integration/expression/tests/within/line-within-collection-of-multipolygons/test.json
+++ b/test/integration/expression/tests/within/line-within-collection-of-multipolygons/test.json
@@ -1,0 +1,62 @@
+{
+    "expression": [
+      "within",
+      {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "MultiPolygon",
+                    "coordinates": [
+                        [[[10, 0], [10, 5], [15, 5], [15, 0], [10, 0]]],
+                        [[[10, 10], [10, 15], [15, 15], [15, 10], [10, 10]]]
+                    ]
+                }
+            },
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "MultiPolygon",
+                    "coordinates": [
+                        [[[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]]],
+                        [[[0, 10], [0, 15], [5, 15], [5, 10], [0, 10]]]
+                    ]
+                }
+            }
+        ]
+      }
+    ],
+    "inputs": [
+      [
+        {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+        {"geometry": {"type": "LineString", "coordinates": [[1, 1], [4, 4]]}}
+      ],
+      [
+        {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+        {"geometry": {"type": "LineString", "coordinates": [[3, 3], [6, 6]]}}
+      ],
+      [
+        {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+        {"geometry": {"type": "LineString", "coordinates": [[11, 1], [14, 4]]}}
+      ],
+      [
+        {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+        {"geometry": {"type": "LineString", "coordinates": [[14, 14], [11, 12]]}}
+      ],
+      [
+        {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+        {"geometry": {"type": "LineString", "coordinates": [[3, 3], [13, 13]]}}
+      ]
+    ],
+    "expected": {
+      "compiled": {
+        "result": "success",
+        "isFeatureConstant": false,
+        "isZoomConstant": true,
+        "type": "boolean"
+      },
+      "outputs": [true, false, true, true, false]
+    }
+  }
+  

--- a/test/integration/expression/tests/within/line-within-collection-of-polygons/test.json
+++ b/test/integration/expression/tests/within/line-within-collection-of-polygons/test.json
@@ -1,0 +1,56 @@
+{
+    "expression": [
+      "within",
+      {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[10, 0], [10, 5], [15, 5], [15, 0], [10, 0]]]
+                }
+            },
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]]]
+                }
+            }
+        ]
+      }
+    ],
+    "inputs": [
+      [
+        {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+        {"geometry": {"type": "LineString", "coordinates": [[1, 1], [4, 4]]}}
+      ],
+      [
+        {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+        {"geometry": {"type": "LineString", "coordinates": [[3, 3], [6, 6]]}}
+      ],
+      [
+        {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+        {"geometry": {"type": "LineString", "coordinates": [[11, 1], [14, 4]]}}
+      ],
+      [
+        {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+        {"geometry": {"type": "LineString", "coordinates": [[11, 1], [16, 4]]}}
+      ],
+      [
+        {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+        {"geometry": {"type": "LineString", "coordinates": [[3, 3], [13, 3]]}}
+      ]
+    ],
+    "expected": {
+      "compiled": {
+        "result": "success",
+        "isFeatureConstant": false,
+        "isZoomConstant": true,
+        "type": "boolean"
+      },
+      "outputs": [true, false, true, false, false]
+    }
+  }
+  

--- a/test/integration/expression/tests/within/point-within-collection-of-multipolygons/test.json
+++ b/test/integration/expression/tests/within/point-within-collection-of-multipolygons/test.json
@@ -1,0 +1,65 @@
+{
+  "expression": [
+    "within",
+    {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+              [[[10, 0], [10, 5], [15, 5], [15, 0], [10, 0]]],
+              [[[110, 0], [110, 5], [115, 5], [115, 0], [110, 0]]]
+            ]
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+              [[[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]]],
+              [[[50, 0], [50, 5], [55, 5], [55, 0], [50, 0]]]
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "inputs": [
+    [
+      {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+      {"geometry": {"type": "Point", "coordinates": [6, 6]}}
+    ],
+    [
+      {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+      {"geometry": {"type": "Point", "coordinates": [2, 2]}}
+    ],
+    [
+      {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+      {"geometry": {"type": "Point", "coordinates": [12, 2]}}
+    ],
+    [
+      {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+      {"geometry": {"type": "Point", "coordinates": [22, 2]}}
+    ],
+    [
+      {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+      {"geometry": {"type": "Point", "coordinates": [52, 2]}}
+    ],    
+    [
+      {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+      {"geometry": {"type": "Point", "coordinates": [112, 2]}}
+    ]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [false, true, true, false, true, true]
+  }
+}

--- a/test/integration/expression/tests/within/point-within-collection-of-polygons/test.json
+++ b/test/integration/expression/tests/within/point-within-collection-of-polygons/test.json
@@ -1,0 +1,48 @@
+{
+    "expression": [
+      "within",
+      {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[10, 0], [10, 5], [15, 5], [15, 0], [10, 0]]]
+                }
+            },
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]]]
+                }
+            }
+        ]
+      }
+    ],
+    "inputs": [
+      [
+        {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+        {"geometry": {"type": "Point", "coordinates": [6, 6]}}
+      ],
+      [
+        {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+        {"geometry": {"type": "Point", "coordinates": [2, 2]}}
+      ],
+      [
+        {"zoom": 3, "canonicalID": {"z": 3, "x": 3, "y": 3}},
+        {"geometry": {"type": "Point", "coordinates": [12, 2]}}
+      ]
+    ],
+    "expected": {
+      "compiled": {
+        "result": "success",
+        "isFeatureConstant": false,
+        "isZoomConstant": true,
+        "type": "boolean"
+      },
+      "outputs": [false, true, true]
+    }
+  }
+  


### PR DESCRIPTION
Fixes https://github.com/maplibre/maplibre-gl-js/issues/3540

A bit verbose perhaps. But if we need to query stuff within multiple polygons, then Within.geometries has to be an array and therefore some changes are necessary here and there.

Of course this will be thoroughly tested after tests' migration from gl-js.

BTW this bug occurs not only with points but **with lines too**. (This is fixed here too).