### PR TITLE
Add missing sky in diff results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+
+- Add missing sky in diff results [#518](https://github.com/maplibre/maplibre-style-spec/pull/518)
 - _...Add new stuff here..._
 
 ## 20.1.0

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -1,481 +1,568 @@
 import diffStyles from './diff';
 import {StyleSpecification} from './types.g';
+import http from 'https';
 
-test('diff', () => {
+describe('diff', () => {
+    test('layers id equal', () => {
+        expect(diffStyles({
+            layers: [{id: 'a'}]
+        } as StyleSpecification, {
+            layers: [{id: 'a'}]
+        } as StyleSpecification)).toEqual([]);
+    });
+    
+    test('version not equal', () => {
+        expect(diffStyles({
+            version: 7,
+            layers: [{id: 'a'}]
+        } as any as StyleSpecification, {
+            version: 8,
+            layers: [{id: 'a'}]
+        } as StyleSpecification)).toEqual([
+            {command: 'setStyle', args: [{version: 8, layers: [{id: 'a'}]}]}
+        ]);
+    });
 
-    expect(diffStyles({
-        layers: [{id: 'a'}]
-    } as StyleSpecification, {
-        layers: [{id: 'a'}]
-    } as StyleSpecification)).toEqual([]);
+    test('add layer at the end', () => {
+        expect(diffStyles({
+            layers: [{id: 'a'}]
+        } as StyleSpecification, {
+            layers: [{id: 'a'}, {id: 'b'}]
+        } as StyleSpecification)).toEqual([
+            {command: 'addLayer', args: [{id: 'b'}, undefined]}
+        ]);
+    });
 
-    expect(diffStyles({
-        version: 7,
-        layers: [{id: 'a'}]
-    } as any as StyleSpecification, {
-        version: 8,
-        layers: [{id: 'a'}]
-    } as StyleSpecification)).toEqual([
-        {command: 'setStyle', args: [{version: 8, layers: [{id: 'a'}]}]}
-    ]);
+    test('add layer at the beginning', () => {
+        expect(diffStyles({
+            layers: [{id: 'b'}]
+        } as StyleSpecification, {
+            layers: [{id: 'a'}, {id: 'b'}]
+        } as StyleSpecification)).toEqual([
+            {command: 'addLayer', args: [{id: 'a'}, 'b']}
+        ]);
+    });
 
-    expect(diffStyles({
-        layers: [{id: 'a'}]
-    } as StyleSpecification, {
-        layers: [{id: 'a'}, {id: 'b'}]
-    } as StyleSpecification)).toEqual([
-        {command: 'addLayer', args: [{id: 'b'}, undefined]}
-    ]);
+    test('remove layer', () => {
+        expect(diffStyles({
+            layers: [{id: 'a'}, {id: 'b', source: 'foo', nested: [1]}]
+        } as StyleSpecification, {
+            layers: [{id: 'a'}]
+        } as StyleSpecification)).toEqual([
+            {command: 'removeLayer', args: ['b']}
+        ]);
+    }); 
 
-    expect(diffStyles({
-        layers: [{id: 'b'}]
-    } as StyleSpecification, {
-        layers: [{id: 'a'}, {id: 'b'}]
-    } as StyleSpecification)).toEqual([
-        {command: 'addLayer', args: [{id: 'a'}, 'b']}
-    ]);
+    test('remove and add layer', () => {
+        expect(diffStyles({
+            layers: [{id: 'a'}, {id: 'b'}]
+        } as StyleSpecification, {
+            layers: [{id: 'b'}, {id: 'a'}]
+        } as StyleSpecification)).toEqual([
+            {command: 'removeLayer', args: ['a']},
+            {command: 'addLayer', args: [{id: 'a'}, undefined]}
+        ]);
+    });
 
-    expect(diffStyles({
-        layers: [{id: 'a'}, {id: 'b', source: 'foo', nested: [1]}]
-    } as StyleSpecification, {
-        layers: [{id: 'a'}]
-    } as StyleSpecification)).toEqual([
-        {command: 'removeLayer', args: ['b']}
-    ]);
+    test('set paint property', () => {
+        expect(diffStyles({
+            layers: [{id: 'a', paint: {foo: 1}}]
+        } as any as StyleSpecification, {
+            layers: [{id: 'a', paint: {foo: 2}}]
+        } as any as StyleSpecification)).toEqual([
+            {command: 'setPaintProperty', args: ['a', 'foo', 2, null]}
+        ]);
+    });
 
-    expect(diffStyles({
-        layers: [{id: 'a'}, {id: 'b'}]
-    } as StyleSpecification, {
-        layers: [{id: 'b'}, {id: 'a'}]
-    } as StyleSpecification)).toEqual([
-        {command: 'removeLayer', args: ['a']},
-        {command: 'addLayer', args: [{id: 'a'}, undefined]}
-    ]);
+    test('set paint property with light', () => {
+        expect(diffStyles({
+            layers: [{id: 'a', 'paint.light': {foo: 1}}]
+        } as any as StyleSpecification, {
+            layers: [{id: 'a', 'paint.light': {foo: 2}}]
+        } as any as StyleSpecification)).toEqual([
+            {command: 'setPaintProperty', args: ['a', 'foo', 2, 'light']}
+        ]);
+    });
 
-    expect(diffStyles({
-        layers: [{id: 'a', paint: {foo: 1}}]
-    } as any as StyleSpecification, {
-        layers: [{id: 'a', paint: {foo: 2}}]
-    } as any as StyleSpecification)).toEqual([
-        {command: 'setPaintProperty', args: ['a', 'foo', 2, null]}
-    ]);
+    test('set paint property with ramp', () => {
+        expect(diffStyles({
+            layers: [{id: 'a', paint: {foo: {ramp: [1, 2]}}}]
+        } as any as StyleSpecification, {
+            layers: [{id: 'a', paint: {foo: {ramp: [1]}}}]
+        } as any as StyleSpecification)).toEqual([
+            {command: 'setPaintProperty', args: ['a', 'foo', {ramp: [1]}, null]}
+        ]);
+    });
 
-    expect(diffStyles({
-        layers: [{id: 'a', 'paint.light': {foo: 1}}]
-    } as any as StyleSpecification, {
-        layers: [{id: 'a', 'paint.light': {foo: 2}}]
-    } as any as StyleSpecification)).toEqual([
-        {command: 'setPaintProperty', args: ['a', 'foo', 2, 'light']}
-    ]);
+    test('set layout property', () => {
+        expect(diffStyles({
+            layers: [{id: 'a', layout: {foo: 1}}]
+        } as any as StyleSpecification, {
+            layers: [{id: 'a', layout: {foo: 2}}]
+        } as any as StyleSpecification)).toEqual([
+            {command: 'setLayoutProperty', args: ['a', 'foo', 2, null]}
+        ]);
+    });
 
-    expect(diffStyles({
-        layers: [{id: 'a', paint: {foo: {ramp: [1, 2]}}}]
-    } as any as StyleSpecification, {
-        layers: [{id: 'a', paint: {foo: {ramp: [1]}}}]
-    } as any as StyleSpecification)).toEqual([
-        {command: 'setPaintProperty', args: ['a', 'foo', {ramp: [1]}, null]}
-    ]);
+    test('set filter', () => {
+        expect(diffStyles({
+            layers: [{id: 'a', filter: ['==', 'foo', 'bar']}]
+        } as StyleSpecification, {
+            layers: [{id: 'a', filter: ['==', 'foo', 'baz']}]
+        }  as StyleSpecification)).toEqual([
+            {command: 'setFilter', args: ['a', ['==', 'foo', 'baz']]}
+        ]);
+    });
 
-    expect(diffStyles({
-        layers: [{id: 'a', layout: {foo: 1}}]
-    } as any as StyleSpecification, {
-        layers: [{id: 'a', layout: {foo: 2}}]
-    } as any as StyleSpecification)).toEqual([
-        {command: 'setLayoutProperty', args: ['a', 'foo', 2, null]}
-    ]);
+    test('remove source', () => {
+        expect(diffStyles({
+            sources: {foo: 1}
+        } as any as StyleSpecification, {
+            sources: {}
+        } as StyleSpecification)).toEqual([
+            {command: 'removeSource', args: ['foo']}
+        ]);
+    });
 
-    expect(diffStyles({
-        layers: [{id: 'a', filter: ['==', 'foo', 'bar']}]
-    } as StyleSpecification, {
-        layers: [{id: 'a', filter: ['==', 'foo', 'baz']}]
-    }  as StyleSpecification)).toEqual([
-        {command: 'setFilter', args: ['a', ['==', 'foo', 'baz']]}
-    ]);
+    test('add source', () => {
+        expect(diffStyles({
+            sources: {}
+        } as StyleSpecification, {
+            sources: {foo: 1}
+        } as any as StyleSpecification)).toEqual([
+            {command: 'addSource', args: ['foo', 1]}
+        ]);
+    });
 
-    expect(diffStyles({
-        sources: {foo: 1}
-    } as any as StyleSpecification, {
-        sources: {}
-    } as StyleSpecification)).toEqual([
-        {command: 'removeSource', args: ['foo']}
-    ]);
-
-    expect(diffStyles({
-        sources: {}
-    } as StyleSpecification, {
-        sources: {foo: 1}
-    } as any as StyleSpecification)).toEqual([
-        {command: 'addSource', args: ['foo', 1]}
-    ]);
-
-    expect(diffStyles({
-        sources: {
-            foo: {
-                type: 'geojson',
-                data: {type: 'FeatureCollection', features: []}
-            }
-        }
-    } as any as StyleSpecification, {
-        sources: {
-            foo: {
-                type: 'geojson',
-                data: {
-                    type: 'FeatureCollection',
-                    features: [{
-                        type: 'Feature',
-                        geometry: {type: 'Point', coordinates: [10, 20]}
-                    }]
+    test('set goejson source data', () => {
+        expect(diffStyles({
+            sources: {
+                foo: {
+                    type: 'geojson',
+                    data: {type: 'FeatureCollection', features: []}
                 }
             }
-        }
-    } as any as StyleSpecification)).toEqual([
-        {command: 'setGeoJSONSourceData', args: ['foo', {
-            type: 'FeatureCollection',
-            features: [{
-                type: 'Feature',
-                geometry: {type: 'Point', coordinates: [10, 20]}
-            }]
-        }]}
-    ]);
+        } as any as StyleSpecification, {
+            sources: {
+                foo: {
+                    type: 'geojson',
+                    data: {
+                        type: 'FeatureCollection',
+                        features: [{
+                            type: 'Feature',
+                            geometry: {type: 'Point', coordinates: [10, 20]}
+                        }]
+                    }
+                }
+            }
+        } as any as StyleSpecification)).toEqual([
+            {command: 'setGeoJSONSourceData', args: ['foo', {
+                type: 'FeatureCollection',
+                features: [{
+                    type: 'Feature',
+                    geometry: {type: 'Point', coordinates: [10, 20]}
+                }]
+            }]}
+        ]);
+    });
 
-    expect(diffStyles({
-        sources: {
-            foo: {
+    test('remove and add source', () => {
+        expect(diffStyles({
+            sources: {
+                foo: {
+                    type: 'geojson',
+                    data: {type: 'FeatureCollection', features: []}
+                }
+            }
+        } as any as StyleSpecification, {
+            sources: {
+                foo: {
+                    type: 'geojson',
+                    data: {type: 'FeatureCollection', features: []},
+                    cluster: true
+                }
+            }
+        } as any as StyleSpecification)).toEqual([
+            {command: 'removeSource', args: ['foo']},
+            {command: 'addSource', args: ['foo', {
                 type: 'geojson',
+                cluster: true,
                 data: {type: 'FeatureCollection', features: []}
-            }
-        }
-    } as any as StyleSpecification, {
-        sources: {
-            foo: {
-                type: 'geojson',
-                data: {type: 'FeatureCollection', features: []},
-                cluster: true
-            }
-        }
-    } as any as StyleSpecification)).toEqual([
-        {command: 'removeSource', args: ['foo']},
-        {command: 'addSource', args: ['foo', {
-            type: 'geojson',
-            cluster: true,
-            data: {type: 'FeatureCollection', features: []}
-        }]}
-    ]);
+            }]}
+        ]);
+    });
 
-    expect(diffStyles({
-        sources: {
-            foo: {
-                type: 'geojson',
-                data: {type: 'FeatureCollection', features: []},
-                cluster: true
+    test('remove and add source with clusterRadius', () => {
+        expect(diffStyles({
+            sources: {
+                foo: {
+                    type: 'geojson',
+                    data: {type: 'FeatureCollection', features: []},
+                    cluster: true
+                }
             }
-        }
-    } as any as StyleSpecification, {
-        sources: {
-            foo: {
+        } as any as StyleSpecification, {
+            sources: {
+                foo: {
+                    type: 'geojson',
+                    data: {type: 'FeatureCollection', features: []},
+                    cluster: true,
+                    clusterRadius: 100
+                }
+            }
+        } as any as StyleSpecification)).toEqual([
+            {command: 'removeSource', args: ['foo']},
+            {command: 'addSource', args: ['foo', {
                 type: 'geojson',
-                data: {type: 'FeatureCollection', features: []},
                 cluster: true,
-                clusterRadius: 100
-            }
-        }
-    } as any as StyleSpecification)).toEqual([
-        {command: 'removeSource', args: ['foo']},
-        {command: 'addSource', args: ['foo', {
-            type: 'geojson',
-            cluster: true,
-            clusterRadius: 100,
-            data: {type: 'FeatureCollection', features: []}
-        }]}
-    ]);
+                clusterRadius: 100,
+                data: {type: 'FeatureCollection', features: []}
+            }]}
+        ]);
+    });
 
-    expect(diffStyles({
-        sources: {
-            foo: {
+    test('remove and add source without clusterRadius', () => {
+        expect(diffStyles({
+            sources: {
+                foo: {
+                    type: 'geojson',
+                    data: {type: 'FeatureCollection', features: []},
+                    cluster: true,
+                    clusterRadius: 100
+                }
+            }
+        } as any as StyleSpecification, {
+            sources: {
+                foo: {
+                    type: 'geojson',
+                    data: {type: 'FeatureCollection', features: []},
+                    cluster: true
+                }
+            }
+        } as any as StyleSpecification)).toEqual([
+            {command: 'removeSource', args: ['foo']},
+            {command: 'addSource', args: ['foo', {
                 type: 'geojson',
-                data: {type: 'FeatureCollection', features: []},
                 cluster: true,
-                clusterRadius: 100
+                data: {type: 'FeatureCollection', features: []}
+            }]}
+        ]);
+    });
+
+    test('global metadata', () => {
+        expect(diffStyles({} as StyleSpecification, {
+            metadata: {'maplibre:author': 'nobody'}
+        } as StyleSpecification)).toEqual([]);
+    });
+
+    test('layer metadata', () => {
+        expect(diffStyles({
+            layers: [{id: 'a', metadata: {'maplibre:group': 'Group Name'}}]
+        } as StyleSpecification, {
+            layers: [{id: 'a', metadata: {'maplibre:group': 'Another Name'}}]
+        } as StyleSpecification)).toEqual([]);
+    });
+
+    test('set center', () => {
+        expect(diffStyles({
+            center: [0, 0]
+        } as StyleSpecification, {
+            center: [1, 1]
+        } as StyleSpecification)).toEqual([
+            {command: 'setCenter', args: [[1, 1]]}
+        ]);
+    });
+
+    test('set zoom', () => {
+        expect(diffStyles({
+            zoom: 12
+        } as StyleSpecification, {
+            zoom: 15
+        } as StyleSpecification)).toEqual([
+            {command: 'setZoom', args: [15]}
+        ]);
+    });
+
+    test('set bearing', () => {
+        expect(diffStyles({
+            bearing: 0
+        } as StyleSpecification, {
+            bearing: 180
+        } as StyleSpecification)).toEqual([
+            {command: 'setBearing', args: [180]}
+        ]);
+    });
+
+    test('set pitch', () => {
+        expect(diffStyles({
+            pitch: 0
+        } as StyleSpecification, {
+            pitch: 1
+        } as StyleSpecification)).toEqual([
+            {command: 'setPitch', args: [1]}
+        ]);
+    });
+
+
+    test('no changes in light', () => {
+        expect(diffStyles({
+            light: {
+                anchor: 'map',
+                color: 'white',
+                position: [0, 1, 0],
+                intensity: 1
             }
-        }
-    } as any as StyleSpecification, {
-        sources: {
-            foo: {
-                type: 'geojson',
-                data: {type: 'FeatureCollection', features: []},
-                cluster: true
+        } as StyleSpecification, {
+            light: {
+                anchor: 'map',
+                color: 'white',
+                position: [0, 1, 0],
+                intensity: 1
             }
-        }
-    } as any as StyleSpecification)).toEqual([
-        {command: 'removeSource', args: ['foo']},
-        {command: 'addSource', args: ['foo', {
-            type: 'geojson',
-            cluster: true,
-            data: {type: 'FeatureCollection', features: []}
-        }]}
-    ]);
+        } as StyleSpecification)).toEqual([
+        ]);
+    });
 
-    expect(diffStyles({} as StyleSpecification, {
-        metadata: {'mapbox:author': 'nobody'}
-    } as StyleSpecification)).toEqual([]);
+    test('set light anchor', () => {
+        expect(diffStyles({
+            light: {anchor: 'map'}
+        } as StyleSpecification, {
+            light: {anchor: 'viewport'}
+        } as StyleSpecification)).toEqual([
+            {command: 'setLight', args: [{'anchor': 'viewport'}]}
+        ]);
+    });
 
-    expect(diffStyles({
-        layers: [{id: 'a', metadata: {'mapbox:group': 'Group Name'}}]
-    } as StyleSpecification, {
-        layers: [{id: 'a', metadata: {'mapbox:group': 'Another Name'}}]
-    } as StyleSpecification)).toEqual([]);
+    test('set light color', () => {
+        expect(diffStyles({
+            light: {color: 'white'}
+        } as StyleSpecification, {
+            light: {color: 'red'}
+        } as StyleSpecification)).toEqual([
+            {command: 'setLight', args: [{'color': 'red'}]}
+        ]);
+    });
 
-    expect(diffStyles({
-        center: [0, 0]
-    } as StyleSpecification, {
-        center: [1, 1]
-    } as StyleSpecification)).toEqual([
-        {command: 'setCenter', args: [[1, 1]]}
-    ]);
+    test('set light position', () => {
+        expect(diffStyles({
+            light: {position: [0, 1, 0]}
+        } as StyleSpecification, {
+            light: {position: [1, 0, 0]}
+        } as StyleSpecification)).toEqual([
+            {command: 'setLight', args: [{'position': [1, 0, 0]}]}
+        ]);
+    });
 
-    expect(diffStyles({
-        zoom: 12
-    } as StyleSpecification, {
-        zoom: 15
-    } as StyleSpecification)).toEqual([
-        {command: 'setZoom', args: [15]}
-    ]);
+    test('set light intensity', () => {
+        expect(diffStyles({
+            light: {intensity: 1}
+        } as StyleSpecification, {
+            light: {intensity: 10}
+        } as StyleSpecification)).toEqual([
+            {command: 'setLight', args: [{'intensity': 10}]}
+        ]);
+    });
 
-    expect(diffStyles({
-        bearing: 0
-    } as StyleSpecification, {
-        bearing: 180
-    } as StyleSpecification)).toEqual([
-        {command: 'setBearing', args: [180]}
-    ]);
+    test('set light anchor and color', () => {
+        expect(diffStyles({
+            light: {
+                anchor: 'map',
+                color: 'orange',
+                position: [2, 80, 30],
+                intensity: 1.0
+            }
+        } as StyleSpecification, {
+            light: {
+                anchor: 'map',
+                color: 'red',
+                position: [1, 40, 30],
+                intensity: 1.0
+            }
+        } as StyleSpecification)).toEqual([
+            {command: 'setLight', args: [{
+                anchor: 'map',
+                color: 'red',
+                position: [1, 40, 30],
+                intensity: 1.0
+            }]}
+        ]);
+    });
 
-    expect(diffStyles({
-        pitch: 0
-    } as StyleSpecification, {
-        pitch: 1
-    } as StyleSpecification)).toEqual([
-        {command: 'setPitch', args: [1]}
-    ]);
+    test('add and remove layer on source change', () => {
+        expect(diffStyles({
+            layers: [{id: 'a', source: 'source-one'}]
+        } as StyleSpecification, {
+            layers: [{id: 'a', source: 'source-two'}]
+        } as StyleSpecification)).toEqual([
+            {command: 'removeLayer', args: ['a']},
+            {command: 'addLayer', args: [{id: 'a', source: 'source-two'}, undefined]}
+        ]);
+    });
 
-    expect(diffStyles({
-        light: {
-            anchor: 'map',
-            color: 'white',
-            position: [0, 1, 0],
-            intensity: 1
-        }
-    } as StyleSpecification, {
-        light: {
-            anchor: 'map',
-            color: 'white',
-            position: [0, 1, 0],
-            intensity: 1
-        }
-    } as StyleSpecification)).toEqual([
-    ]);
+    test('add and remove layer on type change', () => {
+        expect(diffStyles({
+            layers: [{id: 'a', type: 'fill'}]
+        } as StyleSpecification, {
+            layers: [{id: 'a', type: 'line'}]
+        } as StyleSpecification)).toEqual([
+            {command: 'removeLayer', args: ['a']},
+            {command: 'addLayer', args: [{id: 'a', type: 'line'}, undefined]}
+        ]);
+    });
 
-    expect(diffStyles({
-        light: {anchor: 'map'}
-    } as StyleSpecification, {
-        light: {anchor: 'viewport'}
-    } as StyleSpecification)).toEqual([
-        {command: 'setLight', args: [{'anchor': 'viewport'}]}
-    ]);
+    test('add and remove layer on source-layer change', () => {
+        expect(diffStyles({
+            layers: [{id: 'a', source: 'a', 'source-layer': 'layer-one'}]
+        } as StyleSpecification, {
+            layers: [{id: 'a', source: 'a', 'source-layer': 'layer-two'}]
+        } as StyleSpecification)).toEqual([
+            {command: 'removeLayer', args: ['a']},
+            {command: 'addLayer', args: [{id: 'a', source: 'a', 'source-layer': 'layer-two'}, undefined]}
+        ]);
+    });
 
-    expect(diffStyles({
-        light: {color: 'white'}
-    } as StyleSpecification, {
-        light: {color: 'red'}
-    } as StyleSpecification)).toEqual([
-        {command: 'setLight', args: [{'color': 'red'}]}
-    ]);
+    test('add and remove layers on different order and type', () => {
+        expect(diffStyles({
+            layers: [
+                {id: 'b'},
+                {id: 'c'},
+                {id: 'a', type: 'fill'}
+            ]
+        } as StyleSpecification, {
+            layers: [
+                {id: 'c'},
+                {id: 'a', type: 'line'},
+                {id: 'b'}
+            ]
+        } as StyleSpecification)).toEqual([
+            {command: 'removeLayer', args: ['b']},
+            {command: 'addLayer', args: [{id: 'b'}, undefined]},
+            {command: 'removeLayer', args: ['a']},
+            {command: 'addLayer', args: [{id: 'a', type: 'line'}, 'b']}
+        ]);
+    });
 
-    expect(diffStyles({
-        light: {position: [0, 1, 0]}
-    } as StyleSpecification, {
-        light: {position: [1, 0, 0]}
-    } as StyleSpecification)).toEqual([
-        {command: 'setLight', args: [{'position': [1, 0, 0]}]}
-    ]);
+    test('add and remove layer and source on source data change', () => {
+        expect(diffStyles({
+            sources: {foo: {data: 1}, bar: {}},
+            layers: [
+                {id: 'a', source: 'bar'},
+                {id: 'b', source: 'foo'},
+                {id: 'c', source: 'bar'}
+            ]
+        } as any as StyleSpecification, {
+            sources: {foo: {data: 2}, bar: {}},
+            layers: [
+                {id: 'a', source: 'bar'},
+                {id: 'b', source: 'foo'},
+                {id: 'c', source: 'bar'}
+            ]
+        } as any as StyleSpecification)).toEqual([
+            {command: 'removeLayer', args: ['b']},
+            {command: 'removeSource', args: ['foo']},
+            {command: 'addSource', args: ['foo', {data: 2}]},
+            {command: 'addLayer', args: [{id: 'b', source: 'foo'}, 'c']}
+        ]);
+    });
 
-    expect(diffStyles({
-        light: {intensity: 1}
-    } as StyleSpecification, {
-        light: {intensity: 10}
-    } as StyleSpecification)).toEqual([
-        {command: 'setLight', args: [{'intensity': 10}]}
-    ]);
+    test('set transition', () => {
+        expect(diffStyles({
+            sources: {foo: {data: 1}, bar: {}},
+            layers: [
+                {id: 'a', source: 'bar'}
+            ]
+        } as any as StyleSpecification, {
+            sources: {foo: {data: 1}, bar: {}},
+            layers: [
+                {id: 'a', source: 'bar'}
+            ],
+            transition: 'transition'
+        } as any as StyleSpecification)).toEqual([
+            {command: 'setTransition', args: ['transition']}
+        ]);
+    });
 
-    expect(diffStyles({
-        light: {
-            anchor: 'map',
-            color: 'orange',
-            position: [2, 80, 30],
-            intensity: 1.0
-        }
-    } as StyleSpecification, {
-        light: {
-            anchor: 'map',
-            color: 'red',
-            position: [1, 40, 30],
-            intensity: 1.0
-        }
-    } as StyleSpecification)).toEqual([
-        {command: 'setLight', args: [{
-            anchor: 'map',
-            color: 'red',
-            position: [1, 40, 30],
-            intensity: 1.0
-        }]}
-    ]);
+    test('no sprite change', () => {
+        expect(diffStyles({
+            sprite: 'a'
+        } as StyleSpecification, {
+            sprite: 'a'
+        } as StyleSpecification)).toEqual([]);
+    });
 
-    expect(diffStyles({
-        layers: [{id: 'a', source: 'source-one'}]
-    } as StyleSpecification, {
-        layers: [{id: 'a', source: 'source-two'}]
-    } as StyleSpecification)).toEqual([
-        {command: 'removeLayer', args: ['a']},
-        {command: 'addLayer', args: [{id: 'a', source: 'source-two'}, undefined]}
-    ]);
+    test('set sprite', () => {
+        expect(diffStyles({
+            sprite: 'a'
+        } as StyleSpecification, {
+            sprite: 'b'
+        } as StyleSpecification)).toEqual([
+            {command: 'setSprite', args: ['b']},
+        ]);
+    });
 
-    expect(diffStyles({
-        layers: [{id: 'a', type: 'fill'}]
-    } as StyleSpecification, {
-        layers: [{id: 'a', type: 'line'}]
-    } as StyleSpecification)).toEqual([
-        {command: 'removeLayer', args: ['a']},
-        {command: 'addLayer', args: [{id: 'a', type: 'line'}, undefined]}
-    ]);
+    test('set sprite for multiple sprites', () => {
+        expect(diffStyles({
+            sprite: 'a'
+        } as StyleSpecification, {
+            sprite: [{'id': 'default', 'url': 'b'}]
+        } as StyleSpecification)).toEqual([
+            {command: 'setSprite', args: [[{'id': 'default', 'url': 'b'}]]},
+        ]);
+    });
 
-    expect(diffStyles({
-        layers: [{id: 'a', source: 'a', 'source-layer': 'layer-one'}]
-    } as StyleSpecification, {
-        layers: [{id: 'a', source: 'a', 'source-layer': 'layer-two'}]
-    } as StyleSpecification)).toEqual([
-        {command: 'removeLayer', args: ['a']},
-        {command: 'addLayer', args: [{id: 'a', source: 'a', 'source-layer': 'layer-two'}, undefined]}
-    ]);
+    test('no glyphs change', () => {
+        expect(diffStyles({
+            glyphs: 'a'
+        } as StyleSpecification, {
+            glyphs: 'a'
+        } as StyleSpecification)).toEqual([]);
+    });
 
-    expect(diffStyles({
-        layers: [
-            {id: 'b'},
-            {id: 'c'},
-            {id: 'a', type: 'fill'}
-        ]
-    } as StyleSpecification, {
-        layers: [
-            {id: 'c'},
-            {id: 'a', type: 'line'},
-            {id: 'b'}
-        ]
-    } as StyleSpecification)).toEqual([
-        {command: 'removeLayer', args: ['b']},
-        {command: 'addLayer', args: [{id: 'b'}, undefined]},
-        {command: 'removeLayer', args: ['a']},
-        {command: 'addLayer', args: [{id: 'a', type: 'line'}, 'b']}
-    ]);
+    test('set glyphs', () => {
+        expect(diffStyles({
+            glyphs: 'a'
+        } as StyleSpecification, {
+            glyphs: 'b'
+        } as StyleSpecification)).toEqual([
+            {command: 'setGlyphs', args: ['b']},
+        ]);
+    });
 
-    expect(diffStyles({
-        sources: {foo: {data: 1}, bar: {}},
-        layers: [
-            {id: 'a', source: 'bar'},
-            {id: 'b', source: 'foo'},
-            {id: 'c', source: 'bar'}
-        ]
-    } as any as StyleSpecification, {
-        sources: {foo: {data: 2}, bar: {}},
-        layers: [
-            {id: 'a', source: 'bar'},
-            {id: 'b', source: 'foo'},
-            {id: 'c', source: 'bar'}
-        ]
-    } as any as StyleSpecification)).toEqual([
-        {command: 'removeLayer', args: ['b']},
-        {command: 'removeSource', args: ['foo']},
-        {command: 'addSource', args: ['foo', {data: 2}]},
-        {command: 'addLayer', args: [{id: 'b', source: 'foo'}, 'c']}
-    ]);
+    test('remove terrain', () => {
+        expect(diffStyles({
+            terrain: {
+                source: 'maplibre-dem',
+                exaggeration: 1.5
+            }
+        } as StyleSpecification, {
+        } as StyleSpecification)).toEqual([
+            {command: 'setTerrain', args: [undefined]},
+        ]);
+    });
 
-    expect(diffStyles({
-        sources: {foo: {data: 1}, bar: {}},
-        layers: [
-            {id: 'a', source: 'bar'}
-        ]
-    } as any as StyleSpecification, {
-        sources: {foo: {data: 1}, bar: {}},
-        layers: [
-            {id: 'a', source: 'bar'}
-        ],
-        transition: 'transition'
-    } as any as StyleSpecification)).toEqual([
-        {command: 'setTransition', args: ['transition']}
-    ]);
+    test('add terrain', () => {
+        expect(diffStyles({
+        } as StyleSpecification,
+        {
+            terrain: {
+                source: 'maplibre-dem',
+                exaggeration: 1.5
+            }
+        } as StyleSpecification)).toEqual([
+            {command: 'setTerrain', args: [{source: 'maplibre-dem', exaggeration: 1.5}]},
+        ]);
+    });
 
-    expect(diffStyles({
-        sprite: 'a'
-    } as StyleSpecification, {
-        sprite: 'a'
-    } as StyleSpecification)).toEqual([]);
-
-    expect(diffStyles({
-        sprite: 'a'
-    } as StyleSpecification, {
-        sprite: 'b'
-    } as StyleSpecification)).toEqual([
-        {command: 'setSprite', args: ['b']},
-    ]);
-
-    expect(diffStyles({
-        sprite: 'a'
-    } as StyleSpecification, {
-        sprite: [{'id': 'default', 'url': 'b'}]
-    } as StyleSpecification)).toEqual([
-        {command: 'setSprite', args: [[{'id': 'default', 'url': 'b'}]]},
-    ]);
-
-    expect(diffStyles({
-        glyphs: 'a'
-    } as StyleSpecification, {
-        glyphs: 'a'
-    } as StyleSpecification)).toEqual([]);
-
-    expect(diffStyles({
-        glyphs: 'a'
-    } as StyleSpecification, {
-        glyphs: 'b'
-    } as StyleSpecification)).toEqual([
-        {command: 'setGlyphs', args: ['b']},
-    ]);
-
-    expect(diffStyles({
-        terrain: {
-            source: 'maplibre-dem',
-            exaggeration: 1.5
-        }
-    } as StyleSpecification, {
-    } as StyleSpecification)).toEqual([
-        {command: 'setTerrain', args: [undefined]},
-    ]);
-
-    expect(diffStyles({
-    } as StyleSpecification,
-    {
-        terrain: {
-            source: 'maplibre-dem',
-            exaggeration: 1.5
-        }
-    } as StyleSpecification)).toEqual([
-        {command: 'setTerrain', args: [{source: 'maplibre-dem', exaggeration: 1.5}]},
-    ]);
-
-    expect(diffStyles({
-    } as StyleSpecification,
-    {
-        sky: {
-            'fog-color': 'green',
-            'fog-blend': 0.2
-        }
-    } as StyleSpecification)).toEqual([
-        {command: 'setSky', args: [{'fog-color': 'green', 'fog-blend': 0.2}]},
-    ]);
+    test('set sky', () => {
+        expect(diffStyles({
+        } as StyleSpecification,
+        {
+            sky: {
+                'fog-color': 'green',
+                'fog-blend': 0.2
+            }
+        } as StyleSpecification)).toEqual([
+            {command: 'setSky', args: [{'fog-color': 'green', 'fog-blend': 0.2}]},
+        ]);
+    });
 });

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -472,10 +472,10 @@ test('diff', () => {
     } as StyleSpecification,
     {
         sky: {
-            "fog-color": 'green',
-            "fog-blend": 0.2
+            'fog-color': 'green',
+            'fog-blend': 0.2
         }
     } as StyleSpecification)).toEqual([
-        {command: 'setSky', args: [{"fog-color": 'green', "fog-blend": 0.2}]},
+        {command: 'setSky', args: [{'fog-color': 'green', 'fog-blend': 0.2}]},
     ]);
 });

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -1,6 +1,5 @@
 import diffStyles from './diff';
 import {StyleSpecification} from './types.g';
-import http from 'https';
 
 describe('diff', () => {
     test('layers id equal', () => {
@@ -10,7 +9,7 @@ describe('diff', () => {
             layers: [{id: 'a'}]
         } as StyleSpecification)).toEqual([]);
     });
-    
+
     test('version not equal', () => {
         expect(diffStyles({
             version: 7,
@@ -51,7 +50,7 @@ describe('diff', () => {
         } as StyleSpecification)).toEqual([
             {command: 'removeLayer', args: ['b']}
         ]);
-    }); 
+    });
 
     test('remove and add layer', () => {
         expect(diffStyles({
@@ -302,7 +301,6 @@ describe('diff', () => {
             {command: 'setPitch', args: [1]}
         ]);
     });
-
 
     test('no changes in light', () => {
         expect(diffStyles({

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -467,4 +467,15 @@ test('diff', () => {
     } as StyleSpecification)).toEqual([
         {command: 'setTerrain', args: [{source: 'maplibre-dem', exaggeration: 1.5}]},
     ]);
+
+    expect(diffStyles({
+    } as StyleSpecification,
+    {
+        sky: {
+            "fog-color": 'green',
+            "fog-blend": 0.2
+        }
+    } as StyleSpecification)).toEqual([
+        {command: 'setSky', args: [{"fog-color": 'green', "fog-blend": 0.2}]},
+    ]);
 });

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,5 +1,5 @@
 
-import {GeoJSONSourceSpecification, LayerSpecification, LightSpecification, SourceSpecification, SpriteSpecification, StyleSpecification, TerrainSpecification, TransitionSpecification} from './types.g';
+import {GeoJSONSourceSpecification, LayerSpecification, LightSpecification, SkySpecification, SourceSpecification, SpriteSpecification, StyleSpecification, TerrainSpecification, TransitionSpecification} from './types.g';
 import isEqual from './util/deep_equal';
 
 /**
@@ -27,6 +27,7 @@ export type DiffOperationsMap = {
     'setTransition': [TransitionSpecification];
     'setLight': [LightSpecification];
     'setTerrain': [TerrainSpecification];
+    'setSky': [SkySpecification];
 }
 
 export type DiffOperations = keyof DiffOperationsMap;
@@ -299,6 +300,9 @@ function diffStyles(before: StyleSpecification, after: StyleSpecification): Diff
         }
         if (!isEqual(before.terrain, after.terrain)) {
             commands.push({command: 'setTerrain', args: [after.terrain]});
+        }
+        if (!isEqual(before.sky, after.sky)) {
+            commands.push({command: 'setSky', args: [after.sky]});
         }
 
         // Handle changes to `sources`


### PR DESCRIPTION
## Launch Checklist

- #517

Fixes #517 - Add `setSky` to diff results



 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
