### PR TITLE
Docs: Remove "support table" at the end of deprecations

### DIFF
--- a/docs/src/routes/deprecations/index.tsx
+++ b/docs/src/routes/deprecations/index.tsx
@@ -304,24 +304,6 @@ The combining filter "all" takes the three other filters that follow it and requ
 ]
 \`\`\`
 `}/>
-
-            <SDKSupportTable
-                supportItems={{
-                    'basic functionality': {
-                        js: '0.10.0',
-                        android: '2.0.1',
-                        ios: '2.0.0',
-                        macos: '0.1.0'
-                    },
-                    '\`has\` / \`!has\`': {
-                        js: '0.19.0',
-                        android: '4.1.0',
-                        ios: '3.3.0',
-                        macos: '0.1.0'
-                    }}}
-
-            />
-
         </div>
     );
 }


### PR DESCRIPTION
At the end of the Deprecations page (https://maplibre.org/maplibre-style-spec/deprecations/) there is this support table:
> <img width="792" alt="image" src="https://github.com/maplibre/maplibre-style-spec/assets/111561/662fbf50-1eca-42a6-875b-874c63081863">

I don't understand why that would be there talking about the support of `has / !has` which is not what the section "[Combining filters](https://maplibre.org/maplibre-style-spec/deprecations/#combining-filters)" is about.

I am assuming someone forgot to remove it from the page at some point…

This PR removes the table.


## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
