### PR TITLE
Add dependabot for docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    versioning-strategy: increase


### PR DESCRIPTION
Instead of the occasional "bump all", this brings structure.

The docs depend on a few packages below v1.0.0, and I imagine it'll still take some manual intervention from time to time to keep those up, but it's much less, and it's temporary.

Related
- https://github.com/maplibre/maplibre-style-spec/pull/580
- https://github.com/maplibre/maplibre-style-spec/pull/580/files#diff-adfa337ce44dc2902621da20152a048dac41878cf3716dfc4cc56d03aa212a56