### PR TITLE
Clarify documentation of icon-halo-width

### DIFF
--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -5364,7 +5364,7 @@
       "minimum": 0,
       "transition": true,
       "units": "pixels",
-      "doc": "Distance of halo to the icon outline. \nThe unit is in pixels only for SDF sprites that were created with a blur radius of 8, multiplied by the display density. I.e., the radius needs to 16 for `@2x` sprites, etc.",
+      "doc": "Distance of halo to the icon outline. \nThe unit is in pixels only for SDF sprites that were created with a blur radius of 8, multiplied by the display density. I.e., the radius needs to be 16 for `@2x` sprites, etc.",
       "requires": [
         "icon-image"
       ],

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -5364,7 +5364,7 @@
       "minimum": 0,
       "transition": true,
       "units": "pixels",
-      "doc": "Distance of halo to the icon outline.",
+      "doc": "Distance of halo to the icon outline. \nThe unit is in pixels only for SDF sprites that were created with a blur radius of 8, multiplied by the display density. I.e., the radius needs to 16 for `@2x` sprites, etc.",
       "requires": [
         "icon-image"
       ],


### PR DESCRIPTION
As it turns out after discussion and research in https://github.com/maplibre/maplibre-native/issues/2281 , the icon-halo-width only has the same scaling as the text-halo-width if the SDF icons were created with a certain blur radius: 8. This PR documents this.

This does not change the spec, only documents current behavior of maplibre.