### PR TITLE
Track parity with issues, show link to issues in docs

### DIFF
--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -87,6 +87,22 @@ function codeBlockMarkdown(code: string, language = 'json'): string {
     return `\`\`\`${language}\n${code}\n\`\`\`\n`;
 }
 
+/** Renders the contents of a cell in the support matrix
+ * @param support - the support string in the style spec
+ * @returns Markdown for support cell
+ */
+function supportCell(support?: string) {
+    // if no information is present in the style spec, we assume there is no support
+    if (support === undefined) return 'Not supported yet';
+
+    // if the string is an issue link, generate a link to it
+    // there is no support yet but there is a tracking issue
+    const maplibreIssue = /https:\/\/github.com\/maplibre\/[^/]+\/issues\/(\d+)/;
+    const match  = support.match(maplibreIssue);
+    if (match) return `[#${match[1]}](${support})`;
+    return support;
+}
+
 /**
  * Converts the sdk support object to markdown table format.
  * @param support - the sdk support object
@@ -99,7 +115,7 @@ function sdkSupportToMarkdown(support: JsonSdkSupport): string {
     markdown += '|-----------|--------------|-----------|-------|---------|\n';
     for (const row of rows) {
         const supportMatrix = support[row];
-        markdown += `|${row}|${supportMatrix.js || 'Not supported yet'}|${supportMatrix.android || 'Not supported yet'}|${supportMatrix.ios || 'Not supported yet'}|${supportMatrix.macos || 'Not supported yet'}|\n`;
+        markdown += `|${row}|${supportCell(supportMatrix.js)}|${supportCell(supportMatrix.android)}|${supportCell(supportMatrix.ios)}|${supportCell(supportMatrix.macos)}|\n`;
     }
     return markdown;
 

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -2140,7 +2140,7 @@
       "property-type": "data-constant"
     },
     "text-variable-anchor-offset": {
-      "type": "array",
+      "type": "variableAnchorOffsetCollection",
       "requires": [
         "text-field",
         {

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -2140,7 +2140,7 @@
       "property-type": "data-constant"
     },
     "text-variable-anchor-offset": {
-      "type": "variableAnchorOffsetCollection",
+      "type": "array",
       "requires": [
         "text-field",
         {
@@ -2152,10 +2152,14 @@
       "doc": "To increase the chance of placing high-priority labels on the map, you can provide an array of `text-anchor` locations, each paired with an offset value. The renderer will attempt to place the label at each location, in order, before moving on to the next location+offset. Use `text-justify: auto` to choose justification based on anchor position. \n\n The length of the array must be even, and must alternate between enum and point entries. i.e., each anchor location must be accompanied by a point, and that point defines the offset when the corresponding anchor location is used. Positive offset values indicate right and down, while negative values indicate left and up. Anchor locations may repeat, allowing the renderer to try multiple offsets to try and place a label using the same anchor. \n\n When present, this property takes precedence over `text-anchor`, `text-variable-anchor`, `text-offset`, and `text-radial-offset`. \n\n ```json \n { \"text-variable-anchor-offset\": [\"top\", [0, 4], \"left\", [3,0], \"bottom\", [1, 1]] } \n ``` \n\n When the renderer chooses the `top` anchor, `[0, 4]` will be used for `text-offset`; the text will be shifted down by 4 ems. \n\n When the renderer chooses the `left` anchor, `[3, 0]` will be used for `text-offset`; the text will be shifted right by 3 ems.",
       "sdk-support": {
         "basic functionality": {
-          "js": "3.3.0"
+          "js": "3.3.0",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/2358",
+          "android": "https://github.com/maplibre/maplibre-native/issues/2358"
         },
         "data-driven styling": {
-          "js": "3.3.0"
+          "js": "3.3.0",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/2358",
+          "android": "https://github.com/maplibre/maplibre-native/issues/2358"
         }
       },
       "expression": {


### PR DESCRIPTION
This is what is looks like:

<img width="802" alt="image" src="https://github.com/maplibre/maplibre-style-spec/assets/649392/b3510003-1b6c-468a-ad70-c4afe551a0de">

When a link is included instead of a version number, it indicates there is no support yet but there is a tracking issue where people can track progress, or that people can pick up.

I will remove the macOS column in a future PR, as we don't have releases for it.


~I also changed the `type` from `variableAnchorOffsetCollection` to `array` because it is a dead link right now.~