### PR TITLE
Disable search highlight

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,6 @@ theme:
     - content.code.copy
     - toc.follow
     - search.suggest
-    - search.highlight
     - navigation.instant
     - navigation.sections
     - navigation.top  # back to top button


### PR DESCRIPTION
I think it is pretty unhelpful.

<img width="1782" alt="image" src="https://github.com/maplibre/maplibre-style-spec/assets/649392/0efbf87b-ff26-4f0c-b70f-bd86d6de82c3">
