### PR TITLE
Document array of numbers in padding not supported with MapLibre Native

### DIFF
--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -98,7 +98,7 @@ function supportCell(support?: string) {
     // there is no support yet but there is a tracking issue
     const maplibreIssue = /https:\/\/github.com\/maplibre\/[^/]+\/issues\/(\d+)/;
     const match  = support.match(maplibreIssue);
-    if (match) return `[#${match[1]}](${support})`;
+    if (match) return `❌ ([#${match[1]}](${support}))`;
     return support;
 }
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -116,7 +116,7 @@ Enums are a closed set of possible string values. Failing to provide a value wit
 
     MapLibre Native only supports a single float as padding (see [#2363](https://github.com/maplibre/maplibre-native/issues/2368)).
 
-Values are declared similar to [CSS padding syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/padding) syntax:
+An array of floats with syntax similar to [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/padding):
 
 - A single value applies to all four sides, e.g. `[2]`;
 - two values apply to [top/bottom, left/right], e.g. `[2, 3]`;

--- a/docs/types.md
+++ b/docs/types.md
@@ -112,9 +112,10 @@ Enums are a closed set of possible string values. Failing to provide a value wit
 
 ## Padding
 
-!!! note
-
-    MapLibre Native only supports a single float as padding (see [#2363](https://github.com/maplibre/maplibre-native/issues/2368)).
+|SDK Support|MapLibre GL JS|MapLibre Native<br>Android|MapLibre Native<br>iOS|
+|-----------|--------------|-----------|-------|
+|Single number| 0.10.0 | 2.0.1 | 2.0.0 |
+|Array of numbers| 2.2.0 | ❌ ([#2363](https://github.com/maplibre/maplibre-native/issues/2368)) | ❌ ([#2363](https://github.com/maplibre/maplibre-native/issues/2368)) |
 
 An array of numbers with syntax similar to [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/padding):
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -112,10 +112,23 @@ Enums are a closed set of possible string values. Failing to provide a value wit
 
 ## Padding
 
-Paddings are similar to [CCS' padding object](https://developer.mozilla.org/en-US/docs/Web/CSS/padding) where you can specify padding in all directions using a single number, top-bottom left-right using two numbers and top, right, bottom, left using four numbers.
+!!! note
+
+    MapLibre Native only supports a single float as padding (see [#2363](https://github.com/maplibre/maplibre-native/issues/2368)).
+
+Values are declared similar to [CSS padding syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/padding) syntax:
+
+- A single value applies to all four sides, e.g. `[2]`;
+- two values apply to [top/bottom, left/right], e.g. `[2, 3]`;
+- three values apply to [top, left/right, bottom] e.g. `[2, 3, 1]`;
+- four values apply to [top, right, bottom, left], e.g. `[2, 3, 1, 0]`.
+
+A single float is accepted for backwards-compatibility, and treated the same as a one-element array — padding applied to all sides.
+
+The following example applies 2em padding on top and bottom and 3em padding left and right.
 
 ```json
 {
-    "icon-padding": [2]
+    "icon-padding": [2, 3]
 }
 ```

--- a/docs/types.md
+++ b/docs/types.md
@@ -116,7 +116,7 @@ Enums are a closed set of possible string values. Failing to provide a value wit
 
     MapLibre Native only supports a single float as padding (see [#2363](https://github.com/maplibre/maplibre-native/issues/2368)).
 
-An array of floats with syntax similar to [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/padding):
+An array of numbers with syntax similar to [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/padding):
 
 - A single value applies to all four sides, e.g. `[2]`;
 - two values apply to [top/bottom, left/right], e.g. `[2, 3]`;

--- a/docs/types.md
+++ b/docs/types.md
@@ -123,7 +123,7 @@ An array of numbers with syntax similar to [CSS](https://developer.mozilla.org/e
 - three values apply to [top, left/right, bottom] e.g. `[2, 3, 1]`;
 - four values apply to [top, right, bottom, left], e.g. `[2, 3, 1, 0]`.
 
-A single float is accepted for backwards-compatibility, and treated the same as a one-element array — padding applied to all sides.
+A single number is accepted for backwards-compatibility, and treated the same as a one-element array — padding applied to all sides.
 
 The following example applies 2em padding on top and bottom and 3em padding left and right.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,9 @@ markdown_extensions:
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.inlinehilite
+  - admonition
   - pymdownx.snippets
+  - pymdownx.details
   - pymdownx.superfences
   - pymdownx.escapeall:
       hardbreak: True

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,9 +39,7 @@ markdown_extensions:
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.inlinehilite
-  - admonition
   - pymdownx.snippets
-  - pymdownx.details
   - pymdownx.superfences
   - pymdownx.escapeall:
       hardbreak: True

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -1513,6 +1513,9 @@
           "android": "2.0.1",
           "ios": "2.0.0"
         },
+        "different paddings per side": {
+          "js": "2.2.0",
+        },
         "data-driven styling": {
           "js": "2.2.0"
         }

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -1514,7 +1514,7 @@
           "ios": "2.0.0"
         },
         "different paddings per side": {
-          "js": "2.2.0",
+          "js": "2.2.0"
         },
         "data-driven styling": {
           "js": "2.2.0"

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -1503,7 +1503,7 @@
       "type": "padding",
       "default": [2],
       "units": "pixels",
-      "doc": "Size of additional area round the icon bounding box used for detecting symbol collisions. Values are declared using CSS margin shorthand syntax: a single value applies to all four sides; two values apply to [top/bottom, left/right]; three values apply to [top, left/right, bottom]; four values apply to [top, right, bottom, left]. For backwards compatibility, a single bare number is accepted, and treated the same as a one-element array - padding applied to all sides.",
+      "doc": "Size of additional area round the icon bounding box used for detecting symbol collisions.",
       "requires": [
         "icon-image"
       ],
@@ -1512,9 +1512,6 @@
           "js": "0.10.0",
           "android": "2.0.1",
           "ios": "2.0.0"
-        },
-        "different paddings per side": {
-          "js": "2.2.0"
         },
         "data-driven styling": {
           "js": "2.2.0"


### PR DESCRIPTION
I noticed that the Android MapLibre API does not offer a function like `PropertyFactory::iconPadding(Float[] values)`, and using `LayoutPropertyValue("icon-padding", arrayOf(0f, 0f, -14f, -5f))` manually leads to an error being logged:

`Error setting property: icon-padding value must be a number`

I conclude that MapLibre native does not support specifying different paddings for different sides, so let's document that.