### PR TITLE
Ensure all types have corresponding documentation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,6 +46,8 @@
     "no-invalid-this": "off",
     "no-buffer-constructor": "off",
 
+    "require-atomic-updates": ["error", { "allowProperties": true }],
+
     "array-bracket-spacing": "error",
     "consistent-return": "off",
     "global-require": "off",

--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -139,17 +139,19 @@ function requiresToMarkdown(requires: any[]): string {
     return markdown;
 }
 
+type MdLink = {text: string, link: string, anchor?: string};
+
 /**
  * Converts the type to markdown link format - the link should be to the relevant section in the right file.
  * @param type - the type of the property
  * @returns the markdown link string
  */
-function typeToMakrdownLink(type: string): string {
+export function typeToMarkdownLink(type: string): MdLink | null {
     switch (type.toLocaleLowerCase()) {
         case '*':
-            return '';
+            return null;
         case 'promoteid':
-            return ` [${type}](types.md)`;
+            return {text: type, link: "types.md"};
         case 'color':
         case 'number':
         case 'string':
@@ -159,16 +161,21 @@ function typeToMakrdownLink(type: string): string {
         case 'formatted':
         case 'resolvedimage':
         case 'padding':
-            return ` [${type}](types.md#${type.toLocaleLowerCase()})`;
+            return {text: type, link: "types.md", anchor: type.toLocaleLowerCase()};
         case 'filter':
-            return ` [${type}](expressions.md)`;
+            return {text: type, link: "expressions.md"};
         case 'paint':
         case 'layout':
-            return ` [${type}](layers.md#${type.toLocaleLowerCase()})`;
+            return {text: type, link: "layers.md", anchor: type.toLocaleLowerCase()};
         default:
             // top level types have their own file
-            return ` [${type}](${type}.md)`;
+            return {text: type, link: `${type}.md`};
     }
+}
+
+function formatMdLink(mdLink: MdLink) {
+    const {link, text, anchor} = mdLink;
+    return `[${text}](${link}${anchor ? `#${anchor}` : ''})`;
 }
 
 function formatRange(minimum?: number, maximum?: number) {
@@ -190,7 +197,9 @@ function convertPropertyToMarkdown(key: string, value: JsonObject, keyPrefix = '
     if (paintLayoutText) {
         markdown += `[${paintLayoutText}](#${paintLayoutText.toLowerCase()}) property. `;
     }
-    const valueType = typeToMakrdownLink(value.type);
+
+    const mdLink = typeToMarkdownLink(value.type);
+    const valueType = mdLink ? ` ${formatMdLink(mdLink)}` : '';
     if (value.required) {
         markdown += `Required${valueType}`;
     } else {

--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -139,7 +139,7 @@ function requiresToMarkdown(requires: any[]): string {
     return markdown;
 }
 
-type MdLink = {text: string, link: string, anchor?: string};
+type MdLink = {text: string; link: string; anchor?: string};
 
 /**
  * Converts the type to markdown link format - the link should be to the relevant section in the right file.
@@ -151,7 +151,7 @@ export function typeToMarkdownLink(type: string): MdLink | null {
         case '*':
             return null;
         case 'promoteid':
-            return {text: type, link: "types.md"};
+            return {text: type, link: 'types.md'};
         case 'color':
         case 'number':
         case 'string':
@@ -161,12 +161,12 @@ export function typeToMarkdownLink(type: string): MdLink | null {
         case 'formatted':
         case 'resolvedimage':
         case 'padding':
-            return {text: type, link: "types.md", anchor: type.toLocaleLowerCase()};
+            return {text: type, link: 'types.md', anchor: type.toLocaleLowerCase()};
         case 'filter':
-            return {text: type, link: "expressions.md"};
+            return {text: type, link: 'expressions.md'};
         case 'paint':
         case 'layout':
-            return {text: type, link: "layers.md", anchor: type.toLocaleLowerCase()};
+            return {text: type, link: 'layers.md', anchor: type.toLocaleLowerCase()};
         default:
             // top level types have their own file
             return {text: type, link: `${type}.md`};

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -5,7 +5,7 @@ The [`gl-style-migrate`](https://github.com/maplibre/maplibre-style-spec/blob/ma
 
 ## Function
 
-As of [v0.41.0](https://github.com/maplibre/maplibre-gl-js/blob/main/CHANGELOG.md#0410-october-11-2017), [property expressions](./expressions.md) is the preferred method for styling features based on zoom level or the feature's properties. Zoom and property functions are still supported but are not recommended.
+As of [MapLibre GL JS 0.41.0](https://github.com/maplibre/maplibre-gl-js/blob/main/CHANGELOG.md#0410-october-11-2017), [property expressions](./expressions.md) is the preferred method for styling features based on zoom level or the feature's properties. Zoom and property functions are still supported but are not recommended.
 
 The value for any layout or paint property may be specified as a _function_. Functions allow you to make the appearance of a map feature change with the current zoom level and/or the feature's properties.
 

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -2065,7 +2065,7 @@
       "property-type": "data-constant"
     },
     "text-variable-anchor-offset": {
-      "type": "variableAnchorOffsetCollection",
+      "type": "array",
       "requires": [
         "text-field",
         {

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -2065,7 +2065,7 @@
       "property-type": "data-constant"
     },
     "text-variable-anchor-offset": {
-      "type": "array",
+      "type": "variableAnchorOffsetCollection",
       "requires": [
         "text-field",
         {

--- a/test/integration/docs/types.test.ts
+++ b/test/integration/docs/types.test.ts
@@ -1,0 +1,64 @@
+import * as fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import styleSpec from '../../../src/reference/v8.json';
+import { typeToMarkdownLink } from '../../../build/generate-docs';
+
+test("ensure all types have documentation", async () => {
+  /**
+   * Recusive function that gets all {"type": "something"} from object.
+   * 
+   * @param obj (part of) style spec
+   * @param acc accumulator
+   * @returns set of all types found in style spec
+   */
+  function getTypesFromStyleSpec(obj: any, acc: Set<string> = new Set()) {
+    if (typeof obj.type === 'string') return acc.add(obj.type);
+    Object.entries(obj).filter(([key, value]) => key !== 'type' && typeof value === 'object').map(([key, value]) => value).forEach(obj => getTypesFromStyleSpec(obj, acc));
+    return acc;
+  }
+
+  const cachedHeadings: Record<string, Set<string>> = {};
+  /**
+   * Reads all headings from filename
+   * @param filename 
+   * @returns all headings (lowercased) from file
+   */
+  async function getTypesFromDocumentation(filename: string) {
+    if (cachedHeadings[filename]) return cachedHeadings[filename];
+    const typesMd = await fs.open(`docs/${filename}`);
+    const typesFromDocumentation: Set<string> = new Set();
+    for await (const line of typesMd.readLines()) {
+      if (!line.startsWith("#")) continue;
+      const heading = line.split(/[#]+/)[1].trim().toLowerCase();
+      typesFromDocumentation.add(heading);
+    }
+    cachedHeadings[filename] = typesFromDocumentation;
+    return typesFromDocumentation;
+  }
+
+  // we don't care about missing documentation for these types
+  const excludedTypes = new Set([
+    "*",
+    "source",
+    "function",
+    "expression",
+    "property-type"
+  ]);
+  const typesFromStyleSpec = [...getTypesFromStyleSpec(styleSpec)].filter(type => !excludedTypes.has(type));
+
+  for (const type of typesFromStyleSpec) {
+    // get link to documentation for type
+    const markdownLink = typeToMarkdownLink(type);
+    if (!markdownLink) throw new Error(`Failed to generate markdown link for type '${type}'`)
+    const { link, anchor } = markdownLink;
+
+    // check if documentation link exists
+    if (!existsSync(`docs/${link}`)) throw Error(`Type '${type}' links to '${link}' which does not seem to exist`);
+
+    // check if anchor heading is correct
+    if (anchor) {
+      const typesFromDocumentation = await getTypesFromDocumentation(link);
+      if (!typesFromDocumentation.has(anchor)) throw new Error(`Type '${type}' has anchor '${anchor}' which does not exist in '${link}'`)
+    }
+  }
+});

--- a/test/integration/docs/types.test.ts
+++ b/test/integration/docs/types.test.ts
@@ -1,64 +1,64 @@
 import * as fs from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import {existsSync} from 'node:fs';
 import styleSpec from '../../../src/reference/v8.json';
-import { typeToMarkdownLink } from '../../../build/generate-docs';
+import {typeToMarkdownLink} from '../../../build/generate-docs';
 
-test("ensure all types have documentation", async () => {
-  /**
-   * Recusive function that gets all {"type": "something"} from object.
-   * 
-   * @param obj (part of) style spec
-   * @param acc accumulator
-   * @returns set of all types found in style spec
-   */
-  function getTypesFromStyleSpec(obj: any, acc: Set<string> = new Set()) {
-    if (typeof obj.type === 'string') return acc.add(obj.type);
-    Object.entries(obj).filter(([key, value]) => key !== 'type' && typeof value === 'object').map(([key, value]) => value).forEach(obj => getTypesFromStyleSpec(obj, acc));
-    return acc;
-  }
-
-  const cachedHeadings: Record<string, Set<string>> = {};
-  /**
-   * Reads all headings from filename
-   * @param filename 
-   * @returns all headings (lowercased) from file
-   */
-  async function getTypesFromDocumentation(filename: string) {
+const cachedHeadings: Record<string, Set<string>> = {};
+/**
+ * Reads all headings from filename
+ * @param filename
+ * @returns all headings (lowercased) from file
+ */
+async function getTypesFromDocumentation(filename: string) {
     if (cachedHeadings[filename]) return cachedHeadings[filename];
     const typesMd = await fs.open(`docs/${filename}`);
     const typesFromDocumentation: Set<string> = new Set();
     for await (const line of typesMd.readLines()) {
-      if (!line.startsWith("#")) continue;
-      const heading = line.split(/[#]+/)[1].trim().toLowerCase();
-      typesFromDocumentation.add(heading);
+        if (!line.startsWith('#')) continue;
+        const heading = line.split(/[#]+/)[1].trim().toLowerCase();
+        typesFromDocumentation.add(heading);
     }
     cachedHeadings[filename] = typesFromDocumentation;
     return typesFromDocumentation;
-  }
+}
 
-  // we don't care about missing documentation for these types
-  const excludedTypes = new Set([
-    "*",
-    "source",
-    "function",
-    "expression",
-    "property-type"
-  ]);
-  const typesFromStyleSpec = [...getTypesFromStyleSpec(styleSpec)].filter(type => !excludedTypes.has(type));
+/**
+ * Recusive function that gets all {"type": "something"} from object.
+ *
+ * @param obj (part of) style spec
+ * @param acc accumulator
+ * @returns set of all types found in style spec
+ */
+function getTypesFromStyleSpec(obj: any, acc: Set<string> = new Set()) {
+    if (typeof obj.type === 'string') return acc.add(obj.type);
+    Object.entries(obj).filter(([key, value]) => key !== 'type' && typeof value === 'object').map(([_, value]) => value).forEach(obj => getTypesFromStyleSpec(obj, acc));
+    return acc;
+}
 
-  for (const type of typesFromStyleSpec) {
+test('ensure all types have documentation', async () => {
+    // we don't care about missing documentation for these types
+    const excludedTypes = new Set([
+        '*',
+        'source',
+        'function',
+        'expression',
+        'property-type'
+    ]);
+    const typesFromStyleSpec = [...getTypesFromStyleSpec(styleSpec)].filter(type => !excludedTypes.has(type));
+
+    for (const type of typesFromStyleSpec) {
     // get link to documentation for type
-    const markdownLink = typeToMarkdownLink(type);
-    if (!markdownLink) throw new Error(`Failed to generate markdown link for type '${type}'`)
-    const { link, anchor } = markdownLink;
+        const markdownLink = typeToMarkdownLink(type);
+        if (!markdownLink) throw new Error(`Failed to generate markdown link for type '${type}'`);
+        const {link, anchor} = markdownLink;
 
-    // check if documentation link exists
-    if (!existsSync(`docs/${link}`)) throw Error(`Type '${type}' links to '${link}' which does not seem to exist`);
+        // check if documentation link exists
+        if (!existsSync(`docs/${link}`)) throw Error(`Type '${type}' links to '${link}' which does not seem to exist`);
 
-    // check if anchor heading is correct
-    if (anchor) {
-      const typesFromDocumentation = await getTypesFromDocumentation(link);
-      if (!typesFromDocumentation.has(anchor)) throw new Error(`Type '${type}' has anchor '${anchor}' which does not exist in '${link}'`)
+        // check if anchor heading is correct
+        if (anchor) {
+            const typesFromDocumentation = await getTypesFromDocumentation(link);
+            if (!typesFromDocumentation.has(anchor)) throw new Error(`Type '${type}' has anchor '${anchor}' which does not exist in '${link}'`);
+        }
     }
-  }
 });

--- a/test/integration/docs/types.test.ts
+++ b/test/integration/docs/types.test.ts
@@ -42,7 +42,8 @@ test('ensure all types have documentation', async () => {
         'source',
         'function',
         'expression',
-        'property-type'
+        'property-type',
+        'variableAnchorOffsetCollection'  // https://github.com/maplibre/maplibre-style-spec/issues/646
     ]);
     const typesFromStyleSpec = [...getTypesFromStyleSpec(styleSpec)].filter(type => !excludedTypes.has(type));
 


### PR DESCRIPTION
Adds an intergration test that checks if types have documentation.

E.g. if you remove the "Padding" section it will error with

>     Type 'padding' has anchor 'padding' which does not exist in 'types.md'

This is to avoid that we have dead links in the documentation like https://github.com/maplibre/maplibre-style-spec/issues/646