### PR TITLE
Docs: Improve `in` expression example

### DIFF
--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -2791,7 +2791,7 @@
         "doc": "Determines whether an item exists in an array or a substring exists in a string.\n\n - [Measure distances](https://maplibre.org/maplibre-gl-js/docs/examples/measure/)",
         "example": {
           "syntax": {
-            "method": ["value", "value"],
+            "method": [["get", "value"], ["literal", "value"]],
             "result": "boolean"
           },
           "value": ["in", "$type", "Point"]


### PR DESCRIPTION
The goal is to improve https://maplibre.org/maplibre-style-spec/expressions/#in to better explain the two way `in` can be used.

- `["in", ["get", "firstName"], "Hans Müller"]` which would be true for `firstName: "Hans"` (at least that is how I understand the spec)
- `["in", ["get", "firstName"], ["literal", ["Hans", "Dieter", "Rudolf"]]]` which would be true for `firstName: "Hans"`

See also https://github.com/maplibre/maplibre-style-spec/issues/555#issuecomment-2105132417

This change does not reflect this goal, but I think it's the best we can do which how the v8.json file is structured ATM. It does not look like it allows for multiple examples or for the examples to have variations.

