### PR TITLE
Make text-max-width require symbol-placement: point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## main
 
 ### ✨ Features and improvements
+
+- Document `text-max-width` only applies with `symbol-placement: 'point'` - [#666](https://github.com/maplibre/maplibre-style-spec/pull/666)
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -1857,7 +1857,12 @@
       "units": "ems",
       "doc": "The maximum line width for text wrapping.",
       "requires": [
-        "text-field"
+        "text-field",
+        {
+          "symbol-placement": [
+            "point"
+          ]
+        }
       ],
       "sdk-support": {
         "basic functionality": {


### PR DESCRIPTION
When investigating https://github.com/maplibre/maplibre-gl-js/pull/4124, I noticed 'text-max-width' is not used when 'symbol-placement' is anything other than 'point'.  This is an attempt to document this behavior for other users.

Relevant native code: https://github.com/maplibre/maplibre-native/blob/main/src/mbgl/layout/symbol_layout.cpp#L381
Relevant JS code: https://github.com/maplibre/maplibre-gl-js/blob/main/src/symbol/symbol_layout.ts#L159

Edit: Hmm. The docs generation doesn't actually use any requires in the form of `{"propery": "value"}`. So the usefulness of this is pretty minimal at that moment. /shrug.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
