### PR TITLE
`raster-dem` source Native

### DIFF
--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -370,7 +370,9 @@ function createSourcesContent() {
             },
             'sdk-support': {
                 'basic functionality': {
-                    js: '0.43.0'
+                    js: '0.43.0',
+                    android: '6.0.0',
+                    ios: '4.0.0'
                 }
             }
         },


### PR DESCRIPTION
This has been supported for a while.

I think Mapbox forgot to update it.