### PR TITLE
Fix Docker MkDocs dev server

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,4 +66,3 @@ validation:
   absolute_links: warn
   unrecognized_links: warn
   anchors: warn
-strict: true

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "generate-typings": "node --no-warnings --loader ts-node/esm build/generate-typings.ts",
     "generate-docs": "node ${WATCH+--watch} --no-warnings --loader ts-node/esm build/generate-docs.ts",
     "mkdocs": "docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material",
-    "mkdocs-build": "npm run generate-docs && docker run --rm -v ${PWD}:/docs squidfunk/mkdocs-material build",
+    "mkdocs-build": "npm run generate-docs && docker run --rm -v ${PWD}:/docs squidfunk/mkdocs-material build --strict",
     "test-build": "jest --selectProjects=build",
     "test-integration": "jest --selectProjects=integration",
     "test-unit": "jest --selectProjects=unit",


### PR DESCRIPTION
You cannot run MkDocs in Docker while strict mode is enabled. Some maintainers of MkDocs refuse to address this because they do not see value in Docker. It's a whole drama `https://github.com/mkdocs/mkdocs/issues/2108`

Anyway, this PR makes sure that `npm run mkdocs` does not use strict mode and that when building the docs we it still uses strict mode. Run `npm run mkdocs-build` locally or keep an eye out for warnings to make sure it builds without strict errors.