### PR TITLE
Don't type style spec as `any`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ export type StylePropertySpecification = {
 };
 
 import v8Spec from './reference/v8.json' with {type: 'json'};
-const v8 = v8Spec as any;
+const v8 = v8Spec;
 import latest from './reference/latest';
 import derefLayers from './deref';
 import diff from './diff';


### PR DESCRIPTION
This makes it a bit easier to patch it for MapLibre Native.

@HarelM Tdoes not seem to be the same file as `v8.json` for some reason...