### PR TITLE
Validate `sdk-support` in spec, add missing tracking issues

### DIFF
--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -90,9 +90,11 @@ function codeBlockMarkdown(code: string, language = 'json'): string {
  * @param support - the support string in the style spec
  * @returns Markdown for support cell
  */
-function supportCell(support?: string) {
+function supportCell(support?: string): string {
     // if no information is present in the style spec, we assume there is no support
     if (support === undefined) return 'Not supported yet';
+    if (support === 'wontfix') return 'Not planned';
+    if (support === 'supported') return '✅';
 
     // if the string is an issue link, generate a link to it
     // there is no support yet but there is a tracking issue

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,6 @@ export type StylePropertySpecification = {
 };
 
 import v8Spec from './reference/v8.json' with {type: 'json'};
-const v8 = v8Spec;
 import latest from './reference/latest';
 import derefLayers from './deref';
 import diff from './diff';

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ export type StylePropertySpecification = {
 };
 
 import v8Spec from './reference/v8.json' with {type: 'json'};
+const v8 = v8Spec as any;
 import latest from './reference/latest';
 import derefLayers from './deref';
 import diff from './diff';

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ export type StylePropertySpecification = {
 };
 
 import v8Spec from './reference/v8.json' with {type: 'json'};
-const v8 = v8Spec as any;
+const v8 = v8Spec;
 import latest from './reference/latest';
 import derefLayers from './deref';
 import diff from './diff';

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -247,7 +247,8 @@
       "sdk-support": {
         "basic functionality": {
           "android": "9.3.0",
-          "ios": "5.10.0"
+          "ios": "5.10.0",
+          "js": "wontfix"
         }
       }
     },
@@ -328,7 +329,8 @@
       "sdk-support": {
         "basic functionality": {
           "android": "9.3.0",
-          "ios": "5.10.0"
+          "ios": "5.10.0",
+          "js": "wontfix"
         }
       }
     },
@@ -403,7 +405,19 @@
         }
       },
       "default": "mapbox",
-      "doc": "The encoding used by this source. Mapbox Terrain RGB is used by default."
+      "doc": "The encoding used by this source. Mapbox Terrain RGB is used by default.",
+      "sdk-support": {
+        "mapbox, terrarium": {
+          "js": "0.43.0",
+          "ios": "6.0.0",
+          "android": "6.0.0"
+        },
+        "custom": {
+          "js": "3.4.0",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/2783",
+          "android": "https://github.com/maplibre/maplibre-native/issues/2783"
+        }
+      }
     },
     "redFactor": {
       "type": "number",
@@ -411,7 +425,9 @@
       "doc": "Value that will be multiplied by the red channel value when decoding. Only used on custom encodings.",
       "sdk-support": {
         "basic functionality": {
-          "js": "3.4"
+          "js": "3.4.0",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/2783",
+          "android": "https://github.com/maplibre/maplibre-native/issues/2783"
         }
       }
     },
@@ -421,7 +437,9 @@
       "doc": "Value that will be multiplied by the blue channel value when decoding. Only used on custom encodings.",
       "sdk-support": {
         "basic functionality": {
-          "js": "3.4"
+          "js": "3.4.0",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/2783",
+          "android": "https://github.com/maplibre/maplibre-native/issues/2783"
         }
       }
     },
@@ -431,7 +449,9 @@
       "doc": "Value that will be multiplied by the green channel value when decoding. Only used on custom encodings.",
       "sdk-support": {
         "basic functionality": {
-          "js": "3.4"
+          "js": "3.4.0",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/2358",
+          "android": "https://github.com/maplibre/maplibre-native/issues/2783"
         }
       }
     },   
@@ -441,7 +461,9 @@
       "doc": "Value that will be added to the encoding mix when decoding. Only used on custom encodings.",
       "sdk-support": {
         "basic functionality": {
-          "js": "3.4"
+          "js": "3.4.0",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/2783",
+          "android": "https://github.com/maplibre/maplibre-native/issues/2783"
         }
       }
     },    
@@ -452,7 +474,8 @@
       "sdk-support": {
         "basic functionality": {
           "android": "9.3.0",
-          "ios": "5.10.0"
+          "ios": "5.10.0",
+          "js": "wontfix"
         }
       }
     },
@@ -2967,7 +2990,9 @@
         "group": "Ramps, scales, curves",
         "sdk-support": {
           "basic functionality": {
-            "js": "0.49.0"
+            "js": "0.49.0",
+            "ios": "https://github.com/maplibre/maplibre-native/issues/2784",
+            "android": "https://github.com/maplibre/maplibre-native/issues/2784"
           }
         }
       },
@@ -2983,7 +3008,9 @@
         "group": "Ramps, scales, curves",
         "sdk-support": {
           "basic functionality": {
-            "js": "0.49.0"
+            "js": "0.49.0",
+            "ios": "https://github.com/maplibre/maplibre-native/issues/2784",
+            "android": "https://github.com/maplibre/maplibre-native/issues/2784"
           }
         }
       },
@@ -3217,7 +3244,9 @@
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
-            "js": "0.54.0"
+            "js": "0.54.0",
+            "android": "8.4.0",
+            "ios": "supported"
           }
         }
       },
@@ -3431,7 +3460,9 @@
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {
-            "js": "0.46.0"
+            "js": "0.46.0",
+            "ios": "https://github.com/maplibre/maplibre-native/issues/1698",
+            "android": "https://github.com/maplibre/maplibre-native/issues/1698"
           }
         }
       },
@@ -3537,7 +3568,9 @@
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {
-            "js": "0.53.0"
+            "js": "0.53.0",
+            "ios": "supported",
+            "android": "supported"
           }
         }
       },
@@ -4178,7 +4211,8 @@
         "sdk-support": {
           "basic functionality": {
             "js": "0.45.0",
-            "android": "6.6.0"
+            "android": "6.6.0",
+            "ios": "supported"
           }
         }
       },
@@ -4471,7 +4505,9 @@
       "required": true,
       "sdk-support": {
         "basic functionality": {
-          "js": "2.2.0"
+          "js": "2.2.0",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/252",
+          "android": "https://github.com/maplibre/maplibre-native/issues/252"
         }
       }
     },
@@ -4482,7 +4518,9 @@
       "default": 1.0,
       "sdk-support": {
         "basic functionality": {
-          "js": "2.2.0"
+          "js": "2.2.0",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/252",
+          "android": "https://github.com/maplibre/maplibre-native/issues/252"
         }
       }
     }
@@ -4915,7 +4953,8 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.50.0",
-          "ios": "4.7.0"
+          "ios": "4.7.0",
+          "android": "7.0.0"
         }
       },
       "expression": {
@@ -5178,7 +5217,11 @@
           "android": "2.0.1",
           "ios": "2.0.0"
         },
-        "data-driven styling": {}
+        "data-driven styling": {
+          "js": "https://github.com/maplibre/maplibre-gl-js/issues/1235",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/744",
+          "android": "https://github.com/maplibre/maplibre-native/issues/744"
+        }
       },
       "expression": {
         "interpolated": false,

--- a/test/integration/style-spec/validate_spec.test.ts
+++ b/test/integration/style-spec/validate_spec.test.ts
@@ -19,80 +19,78 @@ describe('validate_spec', () => {
     });
 
     test('errors from validate do not contain line numbers', () => {
-        const style = JSON.parse(
-            fs.readFileSync(
-                'test/integration/style-spec/tests/bad-color.input.json',
-                'utf8'
-            )
-        );
+        const style = JSON.parse(fs.readFileSync('test/integration/style-spec/tests/bad-color.input.json', 'utf8'));
 
         const result = validate(style, reference);
         expect(result[0].line).toBeUndefined();
     });
+});
 
-    test('Validate sdk-support in spec', () => {
-        const issueTrackers = {
-            js: 'https://github.com/maplibre/maplibre-gl-js/issues',
-            android: 'https://github.com/maplibre/maplibre-native/issues',
-            ios: 'https://github.com/maplibre/maplibre-native/issues',
-        };
-        const platforms = Object.keys(issueTrackers);
+describe('Validate sdk-support in spec', () => {
+    const issueTrackers = {
+        js: 'https://github.com/maplibre/maplibre-gl-js/issues',
+        android: 'https://github.com/maplibre/maplibre-native/issues',
+        ios: 'https://github.com/maplibre/maplibre-native/issues',
+    };
+    const platforms = Object.keys(issueTrackers);
 
-        function validatePlatforms(platformSupport, path) {
-            const notSupportedOnAnyPlatform = platforms.every(
-                (platform) => !platformSupport[platform]
-            );
+    function validatePlatforms(platformSupport, path) {
+        const notSupportedOnAnyPlatform = platforms.every(
+            (platform) => !platformSupport[platform]
+        );
 
-            for (const platform of platforms) {
+        for (const platform of platforms) {
+            test(`Validate sdk-support ${path.join('.')}`, () => {
                 if (notSupportedOnAnyPlatform) {
                     // don't consider it a problem is something is not supported on any platform
                     return;
                 }
-                if (!platformSupport[platform])
-                    throw new Error(`Missing platform '${platform}' in sdk-support at ${path.join(
-                        '.'
-                    )}.
-Please create a tracking issue and add the link.`);
+
+                if (!platformSupport[platform]) {
+                    console.error(`Missing platform '${platform}' in sdk-support at ${path.join('.')}. Please create a tracking issue and add the link.`);
+                }
+                expect(platformSupport[platform]).toBeTruthy();
 
                 const maplibreIssue =
-          /https:\/\/github.com\/maplibre\/[^/]+\/issues\/(\d+)/;
+      /https:\/\/github.com\/maplibre\/[^/]+\/issues\/(\d+)/;
                 const version = /^\d+\.\d+\.\d+$/;
                 const values = new Set(['supported', 'wontfix']);
 
                 const support = platformSupport[platform];
-                if (
-                    !support.match(maplibreIssue) &&
-          !support.match(version) &&
-          !values.has(support)
-                ) {
-                    throw new Error(
-                        `Unsuppored sdk-support value '${support}'. Use one of the following\n` +
-              '- If supported: version number (e.g. 1.0.0) to indicate support since this version (or "supported" to indicate it has always been supported)\n' +
-              '- If it will never be supported: "wontfix" to indicate it will never be supported\n' +
-              '- A link to a tracking issue'
-                    );
-                }
-            }
-        }
-
-        function validateSdkSupport(sdkSupportObj, path) {
-            Object.entries(sdkSupportObj).map(([key, obj]) =>
-                validatePlatforms(obj, [...path, key])
-            );
-        }
-
-        function checkRoot(specRoot, path) {
-            Object.keys(specRoot).forEach((key) => {
-                if (key === 'sdk-support') {
-                    validateSdkSupport(specRoot[key], path);
-                    return;
-                }
-                if (typeof specRoot[key] === 'object') {
-                    checkRoot(specRoot[key], [...path, key]);
-                }
+                const supportValid = Boolean(support.match(maplibreIssue) || support.match(version) || values.has(support));
+                // Only the following values are supported:
+                // - If supported: version number (e.g. 1.0.0) to indicate support since this version (or "supported" to indicate it has always been supported)
+                // - If it will never be supported: "wontfix" to indicate it will never be supported
+                // - A link to a tracking issue
+                expect(supportValid).toBe(true);
             });
         }
+    }
 
-        checkRoot(reference, []);
-    });
+    /**
+     * @param sdkSupportObj - { "sdk-support": ... }
+     * @param path - path in style spec where this object was found
+     */
+    function validateSdkSupport(sdkSupportObj, path: string[]) {
+        Object.entries(sdkSupportObj).map(([key, obj]) =>
+            validatePlatforms(obj, [...path, key])
+        );
+    }
+
+    /**
+     * Recursive function to traverse style spec and look for { "sdk-support": ... }
+     * */
+    function checkRoot(specRoot, path) {
+        Object.keys(specRoot).forEach((key) => {
+            if (key === 'sdk-support') {
+                validateSdkSupport(specRoot[key], path);
+                return;
+            }
+            if (typeof specRoot[key] === 'object') {
+                checkRoot(specRoot[key], [...path, key]);
+            }
+        });
+    }
+
+    checkRoot(reference, []);
 });

--- a/test/integration/style-spec/validate_spec.test.ts
+++ b/test/integration/style-spec/validate_spec.test.ts
@@ -19,10 +19,80 @@ describe('validate_spec', () => {
     });
 
     test('errors from validate do not contain line numbers', () => {
-        const style = JSON.parse(fs.readFileSync('test/integration/style-spec/tests/bad-color.input.json', 'utf8'));
+        const style = JSON.parse(
+            fs.readFileSync(
+                'test/integration/style-spec/tests/bad-color.input.json',
+                'utf8'
+            )
+        );
 
         const result = validate(style, reference);
         expect(result[0].line).toBeUndefined();
     });
 
+    test('Validate sdk-support in spec', () => {
+        const issueTrackers = {
+            js: 'https://github.com/maplibre/maplibre-gl-js/issues',
+            android: 'https://github.com/maplibre/maplibre-native/issues',
+            ios: 'https://github.com/maplibre/maplibre-native/issues',
+        };
+        const platforms = Object.keys(issueTrackers);
+
+        function validatePlatforms(platformSupport, path) {
+            const notSupportedOnAnyPlatform = platforms.every(
+                (platform) => !platformSupport[platform]
+            );
+
+            for (const platform of platforms) {
+                if (notSupportedOnAnyPlatform) {
+                    // don't consider it a problem is something is not supported on any platform
+                    return;
+                }
+                if (!platformSupport[platform])
+                    throw new Error(`Missing platform '${platform}' in sdk-support at ${path.join(
+                        '.'
+                    )}.
+Please create a tracking issue and add the link.`);
+
+                const maplibreIssue =
+          /https:\/\/github.com\/maplibre\/[^/]+\/issues\/(\d+)/;
+                const version = /^\d+\.\d+\.\d+$/;
+                const values = new Set(['supported', 'wontfix']);
+
+                const support = platformSupport[platform];
+                if (
+                    !support.match(maplibreIssue) &&
+          !support.match(version) &&
+          !values.has(support)
+                ) {
+                    throw new Error(
+                        `Unsuppored sdk-support value '${support}'. Use one of the following\n` +
+              '- If supported: version number (e.g. 1.0.0) to indicate support since this version (or "supported" to indicate it has always been supported)\n' +
+              '- If it will never be supported: "wontfix" to indicate it will never be supported\n' +
+              '- A link to a tracking issue'
+                    );
+                }
+            }
+        }
+
+        function validateSdkSupport(sdkSupportObj, path) {
+            Object.entries(sdkSupportObj).map(([key, obj]) =>
+                validatePlatforms(obj, [...path, key])
+            );
+        }
+
+        function checkRoot(specRoot, path) {
+            Object.keys(specRoot).forEach((key) => {
+                if (key === 'sdk-support') {
+                    validateSdkSupport(specRoot[key], path);
+                    return;
+                }
+                if (typeof specRoot[key] === 'object') {
+                    checkRoot(specRoot[key], [...path, key]);
+                }
+            });
+        }
+
+        checkRoot(reference, []);
+    });
 });


### PR DESCRIPTION
- This PR adds a test that ensures there is a tracking issue for each feature that is at least supported on one platform. This test will fail with a helpful message if this is not the case.
- Using this test, I was able to find all missing tracking issues (and created a few more).
- A special value `"wontfix"` can be used if a feature will never be supported. I used this for MapLibre GL JS and [`volatile`](https://maplibre.org/maplibre-style-spec/sources/#volatile). I think we should avoid these going forward, the spec should be cross-platform.
