### PR TITLE
docs: Fix "at" parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🐞 Bug fixes
 
+- In the documentation, fixed the order of the parameters to the "at" expression. ([#811](https://github.com/maplibre/maplibre-style-spec/pull/811))
 - _...Add new stuff here..._
 
 ## 20.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### 🐞 Bug fixes
 
-- In the documentation, fixed the order of the parameters to the "at" expression. ([#811](https://github.com/maplibre/maplibre-style-spec/pull/811))
 - _...Add new stuff here..._
 
 ## 20.3.1

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -2820,10 +2820,10 @@
         "doc": "Retrieves an item from an array.",
         "example": {
           "syntax": {
-            "method": ["value", "number"],
+            "method": ["number", "value"],
             "result": "value"
           },
-          "value": ["at", ["literal", ["a", "b", "c"]], 1]
+          "value": ["at", 1, ["literal", ["a", "b", "c"]]]
         },
         "group": "Lookup",
         "sdk-support": {


### PR DESCRIPTION
The "at" expression's implementation takes the index as the first argument and the array as the second. The docs had the parameters switched.

Fixes #811.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
