### PR TITLE
Add roll angle to stylesheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### ✨ Features and improvements
 
+* Added `roll` property to stylesheet ([#850](https://github.com/maplibre/maplibre-style-spec/issues/850))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -302,6 +302,15 @@ describe('diff', () => {
         ]);
     });
 
+    test('set roll to undefined', () => {
+        expect(diffStyles({
+            roll: 1
+        } as StyleSpecification, {
+        } as StyleSpecification)).toEqual([
+            {command: 'setRoll', args: [undefined]}
+        ]);
+    });
+
     test('set roll', () => {
         expect(diffStyles({
             roll: 0

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -307,7 +307,7 @@ describe('diff', () => {
             roll: 1
         } as StyleSpecification, {
         } as StyleSpecification)).toEqual([
-            {command: 'setRoll', args: [0]}
+            {command: 'setRoll', args: [undefined]}
         ]);
     });
 

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -302,6 +302,16 @@ describe('diff', () => {
         ]);
     });
 
+    test('set roll', () => {
+        expect(diffStyles({
+            roll: 0
+        } as StyleSpecification, {
+            roll: 1
+        } as StyleSpecification)).toEqual([
+            {command: 'setRoll', args: [1]}
+        ]);
+    });
+
     test('no changes in light', () => {
         expect(diffStyles({
             light: {

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -307,7 +307,7 @@ describe('diff', () => {
             roll: 1
         } as StyleSpecification, {
         } as StyleSpecification)).toEqual([
-            {command: 'setRoll', args: [undefined]}
+            {command: 'setRoll', args: [0]}
         ]);
     });
 

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -22,6 +22,7 @@ export type DiffOperationsMap = {
     'setZoom': [number];
     'setBearing': [number];
     'setPitch': [number];
+    'setRoll': [number];
     'setSprite': [SpriteSpecification];
     'setGlyphs': [string];
     'setTransition': [TransitionSpecification];
@@ -286,6 +287,9 @@ function diffStyles(before: StyleSpecification, after: StyleSpecification): Diff
         }
         if (!isEqual(before.pitch, after.pitch)) {
             commands.push({command: 'setPitch', args: [after.pitch]});
+        }
+        if (!isEqual(before.roll, after.roll)) {
+            commands.push({command: 'setRoll', args: [after.roll]});
         }
         if (!isEqual(before.sprite, after.sprite)) {
             commands.push({command: 'setSprite', args: [after.sprite]});

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -63,8 +63,8 @@
       "sdk-support": {
         "basic functionality": {
           "js": "5.0.0",
-          "android": "wontfix",
-          "ios": "wontfix"
+          "android": "https://github.com/maplibre/maplibre-native/issues/2941",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/2941"
         }
       }
     },

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -62,7 +62,9 @@
       "example": 45,
       "sdk-support": {
         "basic functionality": {
-          "js": "5.0"
+          "js": "5.0.0",
+          "android": "wontfix",
+          "ios": "wontfix"
         }
       }
     },

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -59,7 +59,12 @@
       "default": 0,
       "units": "degrees",
       "doc": "Default roll, in degrees. The roll angle is measured counterclockwise about the camera boresight. The style roll will be used only if the map has not been positioned by other means (e.g. map options or user interaction).",
-      "example": 45
+      "example": 45,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "5.0"
+        }
+      }
     },
     "light": {
       "type": "light",

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -54,6 +54,13 @@
       "doc": "Default pitch, in degrees. Zero is perpendicular to the surface, for a look straight down at the map, while a greater value like 60 looks ahead towards the horizon. The style pitch will be used only if the map has not been positioned by other means (e.g. map options or user interaction).",
       "example": 50
     },
+    "roll": {
+      "type": "number",
+      "default": 0,
+      "units": "degrees",
+      "doc": "Default roll, in degrees. The roll angle is measured counterclockwise about the camera boresight. The style roll will be used only if the map has not been positioned by other means (e.g. map options or user interaction).",
+      "example": 45
+    },
     "light": {
       "type": "light",
       "doc": "The global light source.",

--- a/test/integration/style-spec/tests/roll.input.json
+++ b/test/integration/style-spec/tests/roll.input.json
@@ -1,0 +1,6 @@
+{
+  "version": 8,
+  "roll": "45",
+  "sources": {},
+  "layers": []
+}

--- a/test/integration/style-spec/tests/roll.output-api-supported.json
+++ b/test/integration/style-spec/tests/roll.output-api-supported.json
@@ -1,0 +1,6 @@
+[
+  {
+    "message": "roll: number expected, string found",
+    "line": 3
+  }
+]

--- a/test/integration/style-spec/tests/roll.output.json
+++ b/test/integration/style-spec/tests/roll.output.json
@@ -1,0 +1,6 @@
+[
+  {
+    "message": "roll: number expected, string found",
+    "line": 3
+  }
+]


### PR DESCRIPTION
Add Roll Angle

This PR adds roll angle to the stylesheet.

https://github.com/maplibre/maplibre-style-spec/issues/850
https://github.com/maplibre/maplibre-gl-js/issues/4717
https://github.com/maplibre/maplibre-gl-js/pull/4780

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Write tests for all new functionality.
 - [X] Document any changes to public APIs.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
