### PR TITLE
Update spec to show SDK support for high pitch angles.

### DIFF
--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -52,7 +52,24 @@
       "default": 0,
       "units": "degrees",
       "doc": "Default pitch, in degrees. Zero is perpendicular to the surface, for a look straight down at the map, while a greater value like 60 looks ahead towards the horizon. The style pitch will be used only if the map has not been positioned by other means (e.g. map options or user interaction).",
-      "example": 50
+      "example": 50,
+      "sdk-support": {
+        "0-60 degrees": {
+          "js": "0.8.0",
+          "android": "1.0.0",
+          "ios": "1.0.0"
+        },
+        "0-85 degrees": {
+          "js": "2.0.0",
+          "android": "https://github.com/maplibre/maplibre-native/issues/1909",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/1909"
+        },
+        "0-180 degrees": {
+          "js": "5.0.0",
+          "android": "https://github.com/maplibre/maplibre-native/issues/1909",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/1909"
+        }
+      }
     },
     "roll": {
       "type": "number",


### PR DESCRIPTION
Update spec to show SDK support for high pitch angles (https://github.com/maplibre/maplibre-gl-js/pull/4851).

![image](https://github.com/user-attachments/assets/b4bc28c4-2de8-4ecc-a353-7cdce0a0ccdd)

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
