### PR TITLE
Add centerAltitude to style spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## main
 
 ### ✨ Features and improvements
+
+- Added `centerAltitude` property to stylesheet ([#851](https://github.com/maplibre/maplibre-style-spec/issues/851))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -272,6 +272,25 @@ describe('diff', () => {
         ]);
     });
 
+    test('set centerAltitude to undefined', () => {
+        expect(diffStyles({
+            centerAltitude: 1
+        } as StyleSpecification, {
+        } as StyleSpecification)).toEqual([
+            {command: 'setCenterAltitude', args: [undefined]}
+        ]);
+    });
+
+    test('set centerAltitude', () => {
+        expect(diffStyles({
+            centerAltitude: 0
+        } as StyleSpecification, {
+            centerAltitude: 1
+        } as StyleSpecification)).toEqual([
+            {command: 'setCenterAltitude', args: [1]}
+        ]);
+    });
+
     test('set zoom', () => {
         expect(diffStyles({
             zoom: 12

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -19,6 +19,7 @@ export type DiffOperationsMap = {
     'setLayerZoomRange': [string, number, number];
     'setLayerProperty': [string, string, unknown];
     'setCenter': [number[]];
+    'setCenterAltitude': [number];
     'setZoom': [number];
     'setBearing': [number];
     'setPitch': [number];
@@ -278,6 +279,9 @@ function diffStyles(before: StyleSpecification, after: StyleSpecification): Diff
         }
         if (!isEqual(before.center, after.center)) {
             commands.push({command: 'setCenter', args: [after.center]});
+        }
+        if (!isEqual(before.centerAltitude, after.centerAltitude)) {
+            commands.push({command: 'setCenterAltitude', args: [after.centerAltitude]});
         }
         if (!isEqual(before.zoom, after.zoom)) {
             commands.push({command: 'setZoom', args: [after.zoom]});

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -36,7 +36,7 @@
     },
     "centerAltitude": {
       "type": "number",
-      "doc": "Default map center altitude in meters above sea level.  The style center altitude will be used only if the map has not been positioned by other means (e.g. map options or user interaction).",
+      "doc": "Default map center altitude in meters above sea level. The style center altitude defines the altitude where the camera is looking at and will be used only if the map has not been positioned by other means (e.g. map options or user interaction).",
       "example": 123.4,
       "sdk-support": {
         "basic functionality": {

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -34,6 +34,11 @@
         40.7736
       ]
     },
+    "centerAltitude": {
+      "type": "number",
+      "doc": "Default map center altitude in meters above sea level.  The style center altitude will be used only if the map has not been positioned by other means (e.g. map options or user interaction).",
+      "example": 123.4
+    },
     "zoom": {
       "type": "number",
       "doc": "Default zoom level.  The style zoom will be used only if the map has not been positioned by other means (e.g. map options or user interaction).",

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -37,7 +37,14 @@
     "centerAltitude": {
       "type": "number",
       "doc": "Default map center altitude in meters above sea level.  The style center altitude will be used only if the map has not been positioned by other means (e.g. map options or user interaction).",
-      "example": 123.4
+      "example": 123.4,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "5.0.0",
+          "android": "https://github.com/maplibre/maplibre-native/issues/2980",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/2980"
+        }
+      }
     },
     "zoom": {
       "type": "number",

--- a/test/integration/style-spec/tests/center-altitude.input.json
+++ b/test/integration/style-spec/tests/center-altitude.input.json
@@ -1,0 +1,6 @@
+{
+  "version": 8,
+  "centerAltitude": "123.4",
+  "sources": {},
+  "layers": []
+}

--- a/test/integration/style-spec/tests/center-altitude.output-api-supported.json
+++ b/test/integration/style-spec/tests/center-altitude.output-api-supported.json
@@ -1,0 +1,6 @@
+[
+  {
+    "message": "centerAltitude: number expected, string found",
+    "line": 3
+  }
+]

--- a/test/integration/style-spec/tests/center-altitude.output.json
+++ b/test/integration/style-spec/tests/center-altitude.output.json
@@ -1,0 +1,6 @@
+[
+  {
+    "message": "centerAltitude: number expected, string found",
+    "line": 3
+  }
+]


### PR DESCRIPTION
## Launch Checklist

Add `centerAltitude` to style spec, as discussed here: https://github.com/maplibre/maplibre-style-spec/issues/851

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Write tests for all new functionality.
 - [X] Document any changes to public APIs.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
