### PR TITLE
Rename adaptive `globe` to `globe-to-mercator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
-- Rename adaptive globe from `globe` to `globe-mercator` ([#878](https://github.com/maplibre/maplibre-style-spec/pull/878))
+- Rename adaptive globe from `globe` to `globe-to-mercator` ([#878](https://github.com/maplibre/maplibre-style-spec/pull/878))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
+- Rename adaptive globe from `globe` to `globe-mercator` ([#878](https://github.com/maplibre/maplibre-style-spec/pull/878))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -607,10 +607,10 @@ describe('diff', () => {
         } as StyleSpecification,
         {
             projection: {
-                type: 'globe'
+                type: 'globe-mercator'
             }
         } as StyleSpecification)).toEqual([
-            {command: 'setProjection', args: [{type: 'globe'}]},
+            {command: 'setProjection', args: [{type: 'globe-mercator'}]},
         ]);
     });
 });

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -607,10 +607,10 @@ describe('diff', () => {
         } as StyleSpecification,
         {
             projection: {
-                type: 'globe-mercator'
+                type: 'globe-to-mercator'
             }
         } as StyleSpecification)).toEqual([
-            {command: 'setProjection', args: [{type: 'globe-mercator'}]},
+            {command: 'setProjection', args: [{type: 'globe-to-mercator'}]},
         ]);
     });
 });

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -129,7 +129,7 @@
       "type": "projection",
       "doc": "The projection configuration. **Note:** this definition is still experimental and is under development in maplibre-gl-js.",
       "example": {
-        "type": "globe-mercator"
+        "type": "globe-to-mercator"
       }
     },
     "terrain": {
@@ -4538,7 +4538,7 @@
         ]
       },
       "transition": true,
-      "doc": "How to blend the atmosphere. Where 1 is visible atmosphere and 0 is hidden. It is best to interpolate this expression when using globe-mercator projection."
+      "doc": "How to blend the atmosphere. Where 1 is visible atmosphere and 0 is hidden. It is best to interpolate this expression when using globe-to-mercator projection."
     }
   },
   "terrain": {
@@ -4577,7 +4577,7 @@
         "mercator": {
           "doc": "Web Mercator projection."
         },
-        "globe-mercator": {
+        "globe-to-mercator": {
           "doc":  "Spherical projection with zoom transition to Web Mercator projection."
         }
       }

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -129,7 +129,7 @@
       "type": "projection",
       "doc": "The projection configuration. **Note:** this definition is still experimental and is under development in maplibre-gl-js.",
       "example": {
-        "type": "globe"
+        "type": "globe-mercator"
       }
     },
     "terrain": {
@@ -4538,7 +4538,7 @@
         ]
       },
       "transition": true,
-      "doc": "How to blend the atmosphere. Where 1 is visible atmosphere and 0 is hidden. It is best to interpolate this expression when using globe projection."
+      "doc": "How to blend the atmosphere. Where 1 is visible atmosphere and 0 is hidden. It is best to interpolate this expression when using globe-mercator projection."
     }
   },
   "terrain": {
@@ -4575,10 +4575,10 @@
       "default": "mercator",
       "values": {
         "mercator": {
-          "doc": "The Mercator projection."
+          "doc": "Web Mercator projection."
         },
-        "globe": {
-          "doc": "The globe projection."
+        "globe-mercator": {
+          "doc":  "Spherical projection with zoom transition to Web Mercator projection."
         }
       }
     }

--- a/src/validate/validate_projection.test.ts
+++ b/src/validate/validate_projection.test.ts
@@ -26,11 +26,11 @@ describe('Validate projection', () => {
     test('Should return errors according to spec violations', () => {
         const errors = validateProjection({validateSpec, value: {type: 1 as any}, styleSpec: v8, style: {} as any});
         expect(errors).toHaveLength(1);
-        expect(errors[0].message).toBe('type: expected one of [mercator, globe-mercator], 1 found');
+        expect(errors[0].message).toBe('type: expected one of [mercator, globe-to-mercator], 1 found');
     });
 
     test('Should pass if everything is according to spec', () => {
-        let errors = validateProjection({validateSpec, value: {type: 'globe-mercator'}, styleSpec: v8, style: {} as any});
+        let errors = validateProjection({validateSpec, value: {type: 'globe-to-mercator'}, styleSpec: v8, style: {} as any});
         expect(errors).toHaveLength(0);
         errors = validateProjection({validateSpec, value: {type: 'mercator'}, styleSpec: v8, style: {} as any});
         expect(errors).toHaveLength(0);

--- a/src/validate/validate_projection.test.ts
+++ b/src/validate/validate_projection.test.ts
@@ -26,11 +26,11 @@ describe('Validate projection', () => {
     test('Should return errors according to spec violations', () => {
         const errors = validateProjection({validateSpec, value: {type: 1 as any}, styleSpec: v8, style: {} as any});
         expect(errors).toHaveLength(1);
-        expect(errors[0].message).toBe('type: expected one of [mercator, globe], 1 found');
+        expect(errors[0].message).toBe('type: expected one of [mercator, globe-mercator], 1 found');
     });
 
     test('Should pass if everything is according to spec', () => {
-        let errors = validateProjection({validateSpec, value: {type: 'globe'}, styleSpec: v8, style: {} as any});
+        let errors = validateProjection({validateSpec, value: {type: 'globe-mercator'}, styleSpec: v8, style: {} as any});
         expect(errors).toHaveLength(0);
         errors = validateProjection({validateSpec, value: {type: 'mercator'}, styleSpec: v8, style: {} as any});
         expect(errors).toHaveLength(0);


### PR DESCRIPTION
Rename of the adaptive globe from `globe` to `globe-to-mercator` as was suggested here:

> [Birk](https://github.com/maplibre/maplibre-gl-js/pull/3963#issuecomment-2366733199): it would be great to have the projection API extend well to: https://github.com/maplibre/maplibre-gl-js/issues/168

> _[Harel](https://github.com/maplibre/maplibre-gl-js/pull/3963#issuecomment-2367467741): Maybe we can name it globe-mercator to indicate both are used, IDK._

> _[Jakub](https://github.com/maplibre/maplibre-gl-js/pull/3963#issuecomment-2368243309): I think globe-mercator is a good name._



There are many good [reasons](https://github.com/maplibre/maplibre-style-spec/pull/878#issuecomment-2454718370) for leaving `globe` open to a globe-only projection (no mercator transition), and to be more explicit about what `globe-to-mercator` does. Doing an early rename of the adaptive projection will minimize the impact on plugin authors that are now starting to use our adaptive globe projection:
- https://github.com/maptiler/maptiler-sdk-js/pull/132)

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!