### PR TITLE
Revert "Rename adaptive `globe` to `globe-to-mercator` (#878)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## main
 
 ### ✨ Features and improvements
-- Rename adaptive globe from `globe` to `globe-to-mercator` ([#878](https://github.com/maplibre/maplibre-style-spec/pull/878))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -607,10 +607,10 @@ describe('diff', () => {
         } as StyleSpecification,
         {
             projection: {
-                type: 'globe-to-mercator'
+                type: 'globe'
             }
         } as StyleSpecification)).toEqual([
-            {command: 'setProjection', args: [{type: 'globe-to-mercator'}]},
+            {command: 'setProjection', args: [{type: 'globe'}]},
         ]);
     });
 });

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -129,7 +129,7 @@
       "type": "projection",
       "doc": "The projection configuration. **Note:** this definition is still experimental and is under development in maplibre-gl-js.",
       "example": {
-        "type": "globe-to-mercator"
+        "type": "globe"
       }
     },
     "terrain": {
@@ -4538,7 +4538,7 @@
         ]
       },
       "transition": true,
-      "doc": "How to blend the atmosphere. Where 1 is visible atmosphere and 0 is hidden. It is best to interpolate this expression when using globe-to-mercator projection."
+      "doc": "How to blend the atmosphere. Where 1 is visible atmosphere and 0 is hidden. It is best to interpolate this expression when using globe projection."
     }
   },
   "terrain": {
@@ -4575,10 +4575,10 @@
       "default": "mercator",
       "values": {
         "mercator": {
-          "doc": "Web Mercator projection."
+          "doc": "The Mercator projection."
         },
-        "globe-to-mercator": {
-          "doc":  "Spherical projection with zoom transition to Web Mercator projection."
+        "globe": {
+          "doc": "The globe projection."
         }
       }
     }

--- a/src/validate/validate_projection.test.ts
+++ b/src/validate/validate_projection.test.ts
@@ -26,11 +26,11 @@ describe('Validate projection', () => {
     test('Should return errors according to spec violations', () => {
         const errors = validateProjection({validateSpec, value: {type: 1 as any}, styleSpec: v8, style: {} as any});
         expect(errors).toHaveLength(1);
-        expect(errors[0].message).toBe('type: expected one of [mercator, globe-to-mercator], 1 found');
+        expect(errors[0].message).toBe('type: expected one of [mercator, globe], 1 found');
     });
 
     test('Should pass if everything is according to spec', () => {
-        let errors = validateProjection({validateSpec, value: {type: 'globe-to-mercator'}, styleSpec: v8, style: {} as any});
+        let errors = validateProjection({validateSpec, value: {type: 'globe'}, styleSpec: v8, style: {} as any});
         expect(errors).toHaveLength(0);
         errors = validateProjection({validateSpec, value: {type: 'mercator'}, styleSpec: v8, style: {} as any});
         expect(errors).toHaveLength(0);


### PR DESCRIPTION
This reverts commit d009e1d701b9d0d8dc298b8c87bff4e4a225cdc5. (the changes were published on website, but not in style spec package)

Reverting in favor of
- https://github.com/maplibre/maplibre-style-spec/pull/888#issuecomment-2457853416

It's just so the [website](https://maplibre.org/maplibre-style-spec/projection/) is aligned with published spec, and so these changes doesn't clutter the new expression pr


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
