### PR TITLE
Add `general-perspective` projection. Clarify that `globe` is an adaptive preset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
+Add `stereographic` projection
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
-Add `stereographic` projection
+Add `stereographic` projection ([#890](https://github.com/maplibre/maplibre-style-spec/pull/890))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
-Add `stereographic` projection ([#890](https://github.com/maplibre/maplibre-style-spec/pull/890))
+Add `general-perspective` projection ([#890](https://github.com/maplibre/maplibre-style-spec/pull/890))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -4578,10 +4578,10 @@
           "doc": "Web Mercator projection."
         },
         "globe": {
-          "doc": "Globe projection. Zoom transition from Stereographic projection to Web Mercator projection."
+          "doc": "Globe projection. Zoom transition from General Perspective projection to Web Mercator projection."
         },
-        "stereographic": {
-          "doc": "Stereographic projection."
+        "general-perspective": {
+          "doc": "General Perspective projection."
         }
       }
     }

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -4575,10 +4575,13 @@
       "default": "mercator",
       "values": {
         "mercator": {
-          "doc": "The Mercator projection."
+          "doc": "Web Mercator projection."
         },
         "globe": {
-          "doc": "The globe projection."
+          "doc": "Globe projection. Adaptive transition from Stereographic to Mercator."
+        },
+        "stereographic": {
+          "doc": "Stereographic projection."
         }
       }
     }

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -4578,7 +4578,7 @@
           "doc": "Web Mercator projection."
         },
         "globe": {
-          "doc": "Globe projection. Adaptive transition from Stereographic to Mercator."
+          "doc": "Globe projection. Zoom transition from Stereographic projection to Web Mercator projection."
         },
         "stereographic": {
           "doc": "Stereographic projection."

--- a/src/validate/validate_projection.test.ts
+++ b/src/validate/validate_projection.test.ts
@@ -26,7 +26,7 @@ describe('Validate projection', () => {
     test('Should return errors according to spec violations', () => {
         const errors = validateProjection({validateSpec, value: {type: 1 as any}, styleSpec: v8, style: {} as any});
         expect(errors).toHaveLength(1);
-        expect(errors[0].message).toBe('type: expected one of [mercator, globe], 1 found');
+        expect(errors[0].message).toBe('type: expected one of [mercator, globe, stereographic], 1 found');
     });
 
     test('Should pass if everything is according to spec', () => {

--- a/src/validate/validate_projection.test.ts
+++ b/src/validate/validate_projection.test.ts
@@ -26,7 +26,7 @@ describe('Validate projection', () => {
     test('Should return errors according to spec violations', () => {
         const errors = validateProjection({validateSpec, value: {type: 1 as any}, styleSpec: v8, style: {} as any});
         expect(errors).toHaveLength(1);
-        expect(errors[0].message).toBe('type: expected one of [mercator, globe, stereographic], 1 found');
+        expect(errors[0].message).toBe('type: expected one of [mercator, globe, general-perspective], 1 found');
     });
 
     test('Should pass if everything is according to spec', () => {


### PR DESCRIPTION
With the expression syntax [well underway](https://github.com/maplibre/maplibre-style-spec/pull/888#issuecomment-2461318216), it seems there's a clear need for adding the [General Perspective](https://en.wikipedia.org/wiki/General_Perspective_projection) projection (`general-perspective`) in that way that doesn't break later. It serves as a non-adaptive globe until the expression is in.

We can too clarify that the "globe" is, and will stay as, an adaptive preset that use the `general-perspective` and `mercator` projections.

Having the `genereral-projection` option in GL JS early can help us begin preparing for the introduction of the expressions.

- #888 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
