### PR TITLE
rename general-perspective to vertical-perspective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
-Add `general-perspective` projection ([#890](https://github.com/maplibre/maplibre-style-spec/pull/890))
+Add `vertical-perspective` projection ([#890](https://github.com/maplibre/maplibre-style-spec/pull/890))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -4580,7 +4580,7 @@
         "globe": {
           "doc": "Globe projection. Zoom transition from General Perspective projection to Web Mercator projection."
         },
-        "general-perspective": {
+        "vertical-perspective": {
           "doc": "General Perspective projection."
         }
       }

--- a/src/validate/validate_projection.test.ts
+++ b/src/validate/validate_projection.test.ts
@@ -26,7 +26,7 @@ describe('Validate projection', () => {
     test('Should return errors according to spec violations', () => {
         const errors = validateProjection({validateSpec, value: {type: 1 as any}, styleSpec: v8, style: {} as any});
         expect(errors).toHaveLength(1);
-        expect(errors[0].message).toBe('type: expected one of [mercator, globe, general-perspective], 1 found');
+        expect(errors[0].message).toBe('type: expected one of [mercator, globe, vertical-perspective], 1 found');
     });
 
     test('Should pass if everything is according to spec', () => {


### PR DESCRIPTION
@HarelM , this is a small nit.

We don't have a way to pass config properties to the individual projections right now, so the naming we choose for these presets should probably be as accurate as we can for now. I've been a bit back and forth on this, but I think this is the right call for now to be more accurate, and then if there's a more generic solution, then we can convert i.e. 'vertical-perspective' preset into the 'general-perspective' projection with the right parameters. We just need a minimal way right now to disable `mercator` at high zoom, and this will do.

Technically it's a [Vertical Perspective](https://www.mapthematics.com/ProjectionsList.php?Projection=236#vertical%20perspective) projection that we support. It's how earth looks from space at finite distance, if it was a perfect sphere. It is _a kind_ of [General Perspective projection](https://en.wikipedia.org/wiki/General_Perspective_projection), which the following parameters:

- Projection place tilt
  - angle against azimuth = 0
  - angle from vertical = 0
- Distance to Earth's center, for the point of perspective =  ~30-100km


We don't have a way to pass the params with the `general-perspective` setting, so we might as well be accurate with this for now.

For context, if the projection place in a General Perspective projection has a tilt defined, it's considered to be a:
- [Tilted Perspective projection](https://www.mapthematics.com/ProjectionsList.php?Projection=235#tilted%20perspective) (the image isn't stretched - the output is in fact not a perfect circle)

And if the distance to Earth's center, for the point of perspective, is changed from 30k-100k km to other values in the General Perspective projection math, that'll result in these other well-known projections:

- [Gnomonic/center projection](https://www.mapthematics.com/ProjectionsList.php?Projection=227#gnomonic), if the point of perspective is at the center of the Earth, so 0km.
- [Stereographic projection](https://www.mapthematics.com/ProjectionsList.php?Projection=234#stereographic), if the point of perspective is on the surface of the Earth opposite the center of projection ~ 6,371km (distance from earth core to surface).
- [Orthographic projection](https://www.mapthematics.com/ProjectionsList.php?Projection=232#orthographic), if the point of perspective is at infinity.