### PR TITLE
Tweak - Use strings instead of strings parsed to projection arrays

### DIFF
--- a/src/expression/definitions/coercion.ts
+++ b/src/expression/definitions/coercion.ts
@@ -124,7 +124,7 @@ class Coercion implements Expression {
             case 'resolvedImage':
                 return ResolvedImage.fromString(valueToString(this.args[0].evaluate(ctx)));
             case 'projection':
-                return Projection.parse(this.args[0].evaluate(ctx));
+                return this.args[0].evaluate(ctx);
             default:
                 return valueToString(this.args[0].evaluate(ctx));
         }

--- a/src/expression/definitions/coercion.ts
+++ b/src/expression/definitions/coercion.ts
@@ -1,5 +1,5 @@
 import {BooleanType, ColorType, NumberType, StringType, ValueType} from '../types';
-import {Color, Padding, VariableAnchorOffsetCollection, toString as valueToString, validateRGBA, Projection} from '../values';
+import {Color, Padding, VariableAnchorOffsetCollection, toString as valueToString, validateRGBA} from '../values';
 import RuntimeError from '../runtime_error';
 import Formatted from '../types/formatted';
 import ResolvedImage from '../types/resolved_image';

--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -392,7 +392,7 @@ export function normalizePropertyExpression<T>(
         } else if (specification.type === 'variableAnchorOffsetCollection' && Array.isArray(value)) {
             constant = VariableAnchorOffsetCollection.parse(value as VariableAnchorOffsetCollectionSpecification);
         } else if (specification.type === 'projection' && typeof value === 'string') {
-            constant = Projection.parse(value);
+            constant = value;
         }
         return {
             kind: 'constant',

--- a/src/util/interpolate.test.ts
+++ b/src/util/interpolate.test.ts
@@ -119,7 +119,7 @@ describe('interpolate', () => {
     });
 
     test('interpolate projection', () => {
-        const i11nFn = (t: number) => interpolate.projection(Projection.parse('vertical-perspective'), Projection.parse('mercator'), t);
+        const i11nFn = (t: number) => interpolate.projection('vertical-perspective', 'mercator', t);
         expect(i11nFn(0.5)).toBeInstanceOf(Projection);
         expect(`${i11nFn(0.5)}`).toBe('["vertical-perspective", "mercator", 0.5]');
     });

--- a/src/util/interpolate.ts
+++ b/src/util/interpolate.ts
@@ -39,8 +39,8 @@ function number(from: number, to: number, t: number): number {
     return from + t * (to - from);
 }
 
-function projection(from: Projection, to: Projection, interpolation: number): Projection {
-    return new Projection(from.from, to.to, interpolation);
+function projection(from: string, to: string, interpolation: number): Projection {
+    return new Projection(from, to, interpolation);
 }
 
 function color(from: Color, to: Color, t: number, spaceKey: InterpolationColorSpace = 'rgb'): Color {

--- a/test/integration/expression/tests/interpolate-projection/higher-than-stop/test.json
+++ b/test/integration/expression/tests/interpolate-projection/higher-than-stop/test.json
@@ -38,7 +38,7 @@
         "type": "projection"
       },
       "outputs": [
-          ["mercator", "mercator", 1]
+          "mercator"
       ]
     }
   }

--- a/test/integration/expression/tests/interpolate-projection/lower-than-stop/test.json
+++ b/test/integration/expression/tests/interpolate-projection/lower-than-stop/test.json
@@ -38,7 +38,7 @@
         "type": "projection"
       },
       "outputs": [
-        ["vertical-perspective", "vertical-perspective", 1]
+        "vertical-perspective"
       ]
     }
   }

--- a/test/integration/expression/tests/zoom/interpolate-projection/test.json
+++ b/test/integration/expression/tests/zoom/interpolate-projection/test.json
@@ -18,9 +18,9 @@
       "zoom"
     ],
     0,
-    ["literal", ["vertical-perspective", "vertical-perspective", 1]],
+    "vertical-perspective",
     10,
-    ["literal", ["mercator", "mercator", 1]]
+    "mercator"
   ],
   "inputs": [
     [


### PR DESCRIPTION
@HarelM 

There's still no `interpolate-projection`, but this small extension to your work makes the:

```
  "interpolate",
      [
        "linear"
      ],
      [
        "zoom"
      ],
      8,
      ["vertical-perspective","vertical-perspective",1],
      10,
      ["mercator","mercator",1]
```

Into this, which I find is a lot cleaner:

```
  "interpolate",
      [
        "linear"
      ],
      [
        "zoom"
      ],
      8,
      "vertical-perspective",
      10,
      "mercator"
```

For some reason, I just can't see why it's better for the API to use `["vertical-perspective","vertical-perspective",1]` to describe the zoom stops, when the last element is ignored, and the other duplicated. 

Just to double-check, do you prefer the arrays, even though they hold no additional information than a primitive string?


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
