### PR TITLE
Regression - Fix export of `latest`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import v8Spec from './reference/v8.json' with {type: 'json'};
 const v8 = v8Spec as any;
-import {latest} from './reference/latest';
+import latest from './reference/latest';
 import {derefLayers} from './deref';
 import {diff} from './diff';
 import {ValidationError} from './error/validation_error';

--- a/src/reference/latest.ts
+++ b/src/reference/latest.ts
@@ -1,3 +1,4 @@
 
 import  latest from './v8.json' with { type: 'json' };
+export {latest}
 export default latest as any

--- a/src/reference/latest.ts
+++ b/src/reference/latest.ts
@@ -1,3 +1,3 @@
 
 import  latest from './v8.json' with { type: 'json' };
-export {latest}
+export default latest as any


### PR DESCRIPTION
it's necessary to also have a default export on latest, otherwise it's not in index.d.ts