### PR TITLE
Remove extra "the"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- Remove extra "the"s in the documentation [#922](https://github.com/maplibre/maplibre-style-spec/pull/922)
 - _...Add new stuff here..._
 
 ## 22.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Remove extra "the"s in the documentation [#922](https://github.com/maplibre/maplibre-style-spec/pull/922)
 - _...Add new stuff here..._
 
 ## 22.0.0

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -4248,7 +4248,7 @@
         }
       },
       "is-supported-script": {
-        "doc": "Returns `true` if the input string is expected to render legibly. Returns `false` if the input string contains sections that cannot be rendered without potential loss of meaning (e.g. Indic scripts that require complex text shaping, or right-to-left scripts if the the `mapbox-gl-rtl-text` plugin is not in use in MapLibre GL JS).",
+        "doc": "Returns `true` if the input string is expected to render legibly. Returns `false` if the input string contains sections that cannot be rendered without potential loss of meaning (e.g. Indic scripts that require complex text shaping, or right-to-left scripts if the `mapbox-gl-rtl-text` plugin is not in use in MapLibre GL JS).",
         "example": {
           "syntax": {
             "method": ["string"],
@@ -4529,7 +4529,7 @@
         ]
       },
       "transition": true,
-      "doc": "How to blend the the sky color and the horizon color. Where 1 is blending the color at the middle of the sky and 0 is not blending at all and using the sky color only."
+      "doc": "How to blend the sky color and the horizon color. Where 1 is blending the color at the middle of the sky and 0 is not blending at all and using the sky color only."
     },
     "atmosphere-blend": {
       "type": "number",


### PR DESCRIPTION
Noticed there were a couple of extra "the" in the documentation (i.e. in https://maplibre.org/maplibre-style-spec/sky/#sky-horizon-blend)
<img width="850" alt="Screenshot 2024-11-27 at 12 10 03" src="https://github.com/user-attachments/assets/2e07c1d4-306a-4c59-952c-cbbe101e02e2">

This PR removes them

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
