### PR TITLE
Fixes geometry type filter

### DIFF
--- a/src/feature_filter/feature_filter.test.ts
+++ b/src/feature_filter/feature_filter.test.ts
@@ -171,6 +171,30 @@ describe('filter', () => {
         expect(withinFilter.filter({zoom: 3}, featureInTile, canonical)).toBe(false);
     });
 
+    test('expression, geomtery-type point', () => {
+        const withinFilter = featureFilter(['==', ['geometry-type'], 'Point']);
+        expect(withinFilter.needGeometry).toBe(true);
+        const canonical = {z: 3, x: 3, y: 3} as ICanonicalTileID;
+        const featureInTile = {
+            type: 1,
+            geometry: [[{x:0, y:0}]],
+            properties: {}
+        } as Feature;
+        expect(withinFilter.filter({zoom: 3}, featureInTile, canonical)).toBe(true);
+    });
+
+    test('expression, geomtery-type multipoint', () => {
+        const withinFilter = featureFilter(['==', ['geometry-type'], 'MultiPoint']);
+        expect(withinFilter.needGeometry).toBe(true);
+        const canonical = {z: 3, x: 3, y: 3} as ICanonicalTileID;
+        const featureInTile = {
+            type: 1,
+            geometry: [[{x:0, y:0}], [{x:1, y:1}]],
+            properties: {}
+        } as Feature;
+        expect(withinFilter.filter({zoom: 3}, featureInTile, canonical)).toBe(true);
+    });
+
     legacyFilterTests(featureFilter);
 
 });

--- a/src/feature_filter/index.ts
+++ b/src/feature_filter/index.ts
@@ -103,7 +103,7 @@ function compare(a, b) {
 
 function geometryNeeded(filter) {
     if (!Array.isArray(filter)) return false;
-    if (filter[0] === 'within' || filter[0] === 'distance') return true;
+    if (filter[0] === 'within' || filter[0] === 'distance' || filter[0] === 'geometry-type') return true;
     for (let index = 1; index < filter.length; index++) {
         if (geometryNeeded(filter[index])) return true;
     }


### PR DESCRIPTION
## Launch Checklist

This is a solution to the following issue:
- https://github.com/maplibre/maplibre-gl-js/issues/5103

The problem was that the filter needs a geometry but none was supplied.
This fixes this issue.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.

Before:
![image](https://github.com/user-attachments/assets/cc460592-130e-4536-ac0f-bece9aaba3fe)


After:
![image](https://github.com/user-attachments/assets/db821004-805f-445e-a3f1-27c8a3679f6d)
