### PR TITLE
Check that layers array items are objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### 🐞 Bug fixes
 - Fix RuntimeError class, make it inherited from Error ([#983](https://github.com/maplibre/maplibre-style-spec/issues/983))
+- Validate that `layers` array items are objects instead of throwing an error if not ([!1026](https://github.com/maplibre/maplibre-style-spec/pull/1026))
 
 ## 23.1.0
 

--- a/src/validate/validate_layer.test.ts
+++ b/src/validate/validate_layer.test.ts
@@ -1,0 +1,20 @@
+import {validate} from './validate';
+import {validateLayer} from './validate_layer';
+import v8 from '../reference/v8.json' with {type: 'json'};
+
+test.each([
+    ['number', 1],
+    ['string', '__proto__'],
+    ['boolean', true],
+    ['array', [{}]],
+    ['null', null],
+])('Should return error if layer value is %s instead of an object', (valueType, value) => {
+    const errors = validateLayer({
+        validateSpec: validate,
+        value: value,
+        styleSpec: v8,
+        style: {} as any,
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toBe(`object expected, ${valueType} found`);
+});

--- a/src/validate/validate_layer.ts
+++ b/src/validate/validate_layer.ts
@@ -6,6 +6,7 @@ import {validateFilter} from './validate_filter';
 import {validatePaintProperty} from './validate_paint_property';
 import {validateLayoutProperty} from './validate_layout_property';
 import {extendBy as extend} from '../util/extend';
+import {getType} from '../util/get_type';
 
 export function validateLayer(options) {
     let errors = [];
@@ -14,6 +15,10 @@ export function validateLayer(options) {
     const key = options.key;
     const style = options.style;
     const styleSpec = options.styleSpec;
+
+    if (getType(layer) !== 'object') {
+        return [new ValidationError(key, layer, `object expected, ${getType(layer)} found`)]
+    }
 
     if (!layer.type && !layer.ref) {
         errors.push(new ValidationError(key, layer, 'either "type" or "ref" is required'));


### PR DESCRIPTION
From #1025

Fixes an unhandled error occurring when a non-object type value is used as a layer item, e.g. `layers: [123]`.

For primitive types, this caused an error such as:

```
TypeError: Cannot use 'in' operator to search for 'ref' in 3
    at Object.validateLayer [as layer] (node_modules/@maplibre/maplibre-gl-style-spec/src/validate/validate_layer.ts:34:14)
    at validate (node_modules/@maplibre/maplibre-gl-style-spec/src/validate/validate.ts:96:42)
    at Object.validateArray [as array] (node_modules/@maplibre/maplibre-gl-style-spec/src/validate/validate_array.ts:40:32)
    at validate (node_modules/@maplibre/maplibre-gl-style-spec/src/validate/validate.ts:96:42)
    at validateObject (node_modules/@maplibre/maplibre-gl-style-spec/src/validate/validate_object.ts:38:32)
    at validate (node_modules/@maplibre/maplibre-gl-style-spec/src/validate/validate.ts:99:23)
    at validateStyleMin (node_modules/@maplibre/maplibre-gl-style-spec/src/validate_style.min.ts:35:28)
    at src/fuzz.test.ts:179:11
    at Property.predicate (file://node_modules/fast-check/lib/esm/check/property/Property.js:14:54)
    at Property.run (file://node_modules/fast-check/lib/esm/check/property/Property.generic.js:46:33)
```

at

https://github.com/maplibre/maplibre-style-spec/blob/18d63a6e90bbc4208f55946bef3a920f780cf1a6/src/validate/validate_layer.ts#L34-L39

For `null` values, this caused an error such as:

```
TypeError: Cannot read properties of null (reading 'type')
    at Object.validateLayer [as layer] (node_modules/@maplibre/maplibre-gl-style-spec/src/validate/validate_layer.ts:18:16)
    at validate (node_modules/@maplibre/maplibre-gl-style-spec/src/validate/validate.ts:96:42)
    at Object.validateArray [as array] (node_modules/@maplibre/maplibre-gl-style-spec/src/validate/validate_array.ts:40:32)
    at validate (node_modules/@maplibre/maplibre-gl-style-spec/src/validate/validate.ts:96:42)
    at validateObject (node_modules/@maplibre/maplibre-gl-style-spec/src/validate/validate_object.ts:38:32)
    at validate (node_modules/@maplibre/maplibre-gl-style-spec/src/validate/validate.ts:99:23)
    at validateStyleMin (node_modules/@maplibre/maplibre-gl-style-spec/src/validate_style.min.ts:35:28)
    at src/fuzz.test.ts:179:11
    at Property.predicate (file://node_modules/fast-check/lib/esm/check/property/Property.js:14:54)
    at Property.run (file://node_modules/fast-check/lib/esm/check/property/Property.generic.js:46:33)
```

at

https://github.com/maplibre/maplibre-style-spec/blob/18d63a6e90bbc4208f55946bef3a920f780cf1a6/src/validate/validate_layer.ts#L18-L20

After this PR, a validation error is returned with a more user-friendly error: `object expected, number found`

Example style:

```
{
  "version": 8,
  "layers": [null, 1],
  "sources": {
    "maplibre": {
      "url": "https://demotiles.maplibre.org/tiles/tiles.json",
      "type": "vector"
    }
  }
}

```

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
