### PR TITLE
Fix prototype keys causing crash in color parsing and invalid colors in color coercion expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 ### 🐞 Bug fixes
 - Fix RuntimeError class, make it inherited from Error ([#983](https://github.com/maplibre/maplibre-style-spec/issues/983))
 - Fix `validate_object` crashing when object prototype keys used in style's objects ([#1028](https://github.com/maplibre/maplibre-style-spec/pull/1028))
-- Validate that `layers` array items are objects instead of throwing an error if not ([!1026](https://github.com/maplibre/maplibre-style-spec/pull/1026))
+- Validate that `layers` array items are objects instead of throwing an error if not ([#1026](https://github.com/maplibre/maplibre-style-spec/pull/1026))
+- Fix `validate_color` crashing when object prototype keys used as color strings ([#1036](https://github.com/maplibre/maplibre-style-spec/pull/1036))
+- Fix color coercion in expressions (e.g. `to_color`) producing invalid colors when object prototype keys used as color strings ([#1036](https://github.com/maplibre/maplibre-style-spec/pull/1036))
 
 ## 23.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 
 ### 🐞 Bug fixes
 - Fix RuntimeError class, make it inherited from Error ([#983](https://github.com/maplibre/maplibre-style-spec/issues/983))
-- Fix `validate_object` crashing when object prototype keys used in style's objects ([#1028](https://github.com/maplibre/maplibre-style-spec/pull/1028))
 - Validate that `layers` array items are objects instead of throwing an error if not ([#1026](https://github.com/maplibre/maplibre-style-spec/pull/1026))
-- Fix `validate_color` crashing when object prototype keys used as color strings ([#1036](https://github.com/maplibre/maplibre-style-spec/pull/1036))
-- Fix color coercion in expressions (e.g. `to_color`) producing invalid colors when object prototype keys used as color strings ([#1036](https://github.com/maplibre/maplibre-style-spec/pull/1036))
+- Multiple fixes related to validating and parsing of strings containing object prototype keys
+   - Fix `validate_object` crashing when object prototype keys used in style's objects ([#1028](https://github.com/maplibre/maplibre-style-spec/pull/1028))
+   - Fix `validate_color` crashing when object prototype keys used as color strings ([#1036](https://github.com/maplibre/maplibre-style-spec/pull/1036))
+   - Fix color coercion in expressions (e.g. `to_color`) producing invalid colors when object prototype keys used as color strings ([#1036](https://github.com/maplibre/maplibre-style-spec/pull/1036))
 
 ## 23.1.0
 

--- a/src/expression/evaluation_context.ts
+++ b/src/expression/evaluation_context.ts
@@ -13,16 +13,14 @@ export class EvaluationContext {
     availableImages: Array<string>;
     canonical: ICanonicalTileID;
 
-    _parseColorCache: {[_: string]: Color};
+    _parseColorCache: Map<string, Color>;
 
     constructor() {
         this.globals = null;
         this.feature = null;
         this.featureState = null;
         this.formattedSection = null;
-        // the cache keys are user controlled (from the source JSON), so
-        // avoid prototype pollution by creating a record with a null prototype
-        this._parseColorCache = Object.create(null) as {[_: string]: Color};
+        this._parseColorCache = new Map<string, Color>();
         this.availableImages = null;
         this.canonical = null;
     }
@@ -48,9 +46,10 @@ export class EvaluationContext {
     }
 
     parseColor(input: string): Color {
-        let cached = this._parseColorCache[input];
+        let cached = this._parseColorCache.get(input);
         if (!cached) {
-            cached = this._parseColorCache[input] = Color.parse(input);
+            cached = Color.parse(input);
+            this._parseColorCache.set(input, cached);
         }
         return cached;
     }

--- a/src/expression/evaluation_context.ts
+++ b/src/expression/evaluation_context.ts
@@ -20,7 +20,9 @@ export class EvaluationContext {
         this.feature = null;
         this.featureState = null;
         this.formattedSection = null;
-        this._parseColorCache = {};
+        // the cache keys are user controlled (from the source JSON), so
+        // avoid prototype pollution by creating a record with a null prototype
+        this._parseColorCache = Object.create(null) as {[_: string]: Color};
         this.availableImages = null;
         this.canonical = null;
     }

--- a/src/expression/types/parse_css_color.test.ts
+++ b/src/expression/types/parse_css_color.test.ts
@@ -31,6 +31,8 @@ describe('parseCssColor', () => {
             expect(parse('aqua-marine')).toBeUndefined();
             expect(parse('aqua_marine')).toBeUndefined();
             expect(parse('aqua marine')).toBeUndefined();
+            expect(parse('__proto__')).toBeUndefined();
+            expect(parse('valueOf')).toBeUndefined();
         });
 
     });

--- a/src/expression/types/parse_css_color.ts
+++ b/src/expression/types/parse_css_color.ts
@@ -1,3 +1,4 @@
+import {getOwn} from '../../util/get_own';
 import {HSLColor, hslToRgb, RGBColor} from './color_spaces';
 
 /**
@@ -37,7 +38,7 @@ export function parseCssColor(input: string): RGBColor | undefined {
     }
 
     // 'white', 'black', 'blue'
-    const namedColorsMatch = namedColors[input];
+    const namedColorsMatch = getOwn(namedColors, input);
     if (namedColorsMatch) {
         const [r, g, b] = namedColorsMatch;
         return [r / 255, g / 255, b / 255, 1];

--- a/test/integration/expression/tests/to-color/basic/test.json
+++ b/test/integration/expression/tests/to-color/basic/test.json
@@ -27,6 +27,14 @@
       {},
       {
         "properties": {
+          "x": "__proto__"
+        }
+      }
+    ],
+    [
+      {},
+      {
+        "properties": {
           "x": "rgba(0, 255, 0, 1)"
         }
       }
@@ -84,6 +92,9 @@
       ],
       {
         "error": "Could not parse color from value 'invalid'"
+      },
+      {
+        "error": "Could not parse color from value '__proto__'"
       },
       [
         0,

--- a/test/integration/style-spec/tests/bad-color.input.json
+++ b/test/integration/style-spec/tests/bad-color.input.json
@@ -25,6 +25,22 @@
       "paint": {
         "fill-outline-color": ["darken", 10, "#FF0000"]
       }
+    },
+    {
+      "id": "prototype",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "layer",
+      "paint": {
+        "fill-color": "__proto__",
+        "fill-outline-color":  {
+          "property": "fill",
+          "stops": [
+            [{ "zoom": 10, "value": 10 }, "valueOf"],
+            [{ "zoom": 11, "value": 20 }, "__proto__"]
+          ]
+        }
+      }
     }
   ]
 }

--- a/test/integration/style-spec/tests/bad-color.output.json
+++ b/test/integration/style-spec/tests/bad-color.output.json
@@ -10,5 +10,17 @@
   {
     "message": "layers[1].paint.fill-outline-color: color expected, array found",
     "line": 26
+  },
+  {
+    "message": "layers[2].paint.fill-color: color expected, \"__proto__\" found",
+    "line": 35
+  },
+  {
+    "message": "layers[2].paint.fill-outline-color.stops[0][1]: color expected, \"valueOf\" found",
+    "line": 39
+  },
+  {
+    "message": "layers[2].paint.fill-outline-color.stops[1][1]: color expected, \"__proto__\" found",
+    "line": 40
   }
 ]

--- a/test/integration/style-spec/tests/light-malformed-color.input.json
+++ b/test/integration/style-spec/tests/light-malformed-color.input.json
@@ -1,0 +1,16 @@
+{
+  "version": 8,
+  "sources": {
+    "vector": {
+      "type": "vector",
+      "url": "https://demotiles.maplibre.org/tiles/tiles.json"
+    }
+  },
+  "light": {
+    "anchor": "map",
+    "position": [1, 90, 90],
+    "color": "__proto__",
+    "intensity": 0.75
+  },
+  "layers": []
+}

--- a/test/integration/style-spec/tests/light-malformed-color.output.json
+++ b/test/integration/style-spec/tests/light-malformed-color.output.json
@@ -1,0 +1,6 @@
+[
+  {
+    "message": "color: color expected, \"__proto__\" found",
+    "line": 12
+  }
+]


### PR DESCRIPTION
From #1025

This PR fixes two issues:
1. When parsing color strings (e.g. `text-color: "red"`), `parse_css_color.ts` attempted to look up named colors from an object literal by doing `namedColors[input]`. If the color string was `"__proto__"` or `"toString"` or some other key in the `Object` prototype, the value was truthy, and caused an unhandled error to be thrown because the value was destructured.
   https://github.com/maplibre/maplibre-style-spec/blob/91175b30b548f27527ec9d3ac09b73fed31cf699/src/expression/types/parse_css_color.ts#L40-L44
2. When a `Coercion` expression was used to coerce an expression's string value to a color (e.g. `to_color`), it used `EvaluationContext.parseColor()` which checked if the string had already been parsed and cached. The cache lookup was done via `this._parseColorCache[input]`, where `input` comes from the user controlled style. As a result, the input was never parsed as the value was truthy, and the value from the prototype was returned and became the expression's value.
   https://github.com/maplibre/maplibre-style-spec/blob/91175b30b548f27527ec9d3ac09b73fed31cf699/src/expression/evaluation_context.ts#L16
   https://github.com/maplibre/maplibre-style-spec/blob/91175b30b548f27527ec9d3ac09b73fed31cf699/src/expression/evaluation_context.ts#L48-L53

Fixing issue 1 revealed issue 2, as `EvaluationContext.parseColor()` used `Color.parse()` which used `parseCssColor()`. `Color.parse()` is also used in `function` expressions.

The fixes for the issues were:
1. For `parseCssColor()`, since we probably want the convenience of using an object literal to initialize it, I opted to use the previously introduced (#1028) `getOwn()` utility to ensure that only the literal's keys are tested.
2. For `EvaluationContext.parseColor()`, the ` _parseColorCache` was previously initialized to an empty object literal `{}`. Since there was no need for the ergonomics of using a literal, I replaced it with `Object.create(null)` which creates an object without a prototype (note: `{}` is syntactic sugar for `Object.create(Object.prototype)`).

The ideal solution for this would be to systematically use a `Map` if the key is user-controlled, but I did not find any uses of it from the codebase and assumed that the library targets ES5 compatibility.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
