### PR TITLE
min-length for numberArray and colorArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🐞 Bug fixes
 
+- Validate that hillshade illumination parameters are non-empty ([#1094](https://github.com/maplibre/maplibre-style-spec/pull/1094))
 - _...Add new stuff here..._
 
 ## 23.2.0

--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -231,6 +231,9 @@ function convertPropertyToMarkdown(key: string, value: JsonObject, keyPrefix = '
     if (value.units) {
         markdown += `Units in ${value.units}. `;
     }
+    if (value['min-length'] !== undefined) {
+        markdown += `Length >= \`${value['min-length']}\`. `;
+    }
     if (value.default !== undefined) {
         markdown += `Defaults to \`${JSON.stringify(value.default)}\`. `;
     }

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -6478,6 +6478,7 @@
   "paint_hillshade": {
     "hillshade-illumination-direction": {
       "type": "numberArray",
+      "min-length": 1,
       "default": 335,
       "minimum": 0,
       "maximum": 359,
@@ -6505,6 +6506,7 @@
     },
     "hillshade-illumination-altitude": {
       "type": "numberArray",
+      "min-length": 1,
       "default": 45,
       "minimum": 0,
       "maximum": 90,
@@ -6581,6 +6583,7 @@
     },
     "hillshade-shadow-color": {
       "type": "colorArray",
+      "min-length": 1,
       "default": "#000000",
       "doc": "The shading color of areas that face away from the light source(s). Only when `hillshade-method` is set to `multidirectional` can you specify multiple light sources.",
       "transition": true,
@@ -6606,6 +6609,7 @@
     },
     "hillshade-highlight-color": {
       "type": "colorArray",
+      "min-length": 1,
       "default": "#FFFFFF",
       "doc": "The shading color of areas that faces towards the light source(s). Only when `hillshade-method` is set to `multidirectional` can you specify multiple light sources.",
       "transition": true,

--- a/src/validate/validate_color_array.test.ts
+++ b/src/validate/validate_color_array.test.ts
@@ -66,4 +66,19 @@ describe('Validate ColorArray', () => {
         errors = validateColorArray({validateSpec: validate, key: 'colorArray', value: ['red', 'blue', '#012', '#12345678', '#012345']});
         expect(errors).toHaveLength(0);
     });
+    
+    test('Should enforce min-length property', () => {
+        let errors = validateColorArray({validateSpec: validate, key: 'colorArray', value: [], valueSpec: {'min-length': 1}});
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toBe('colorArray: array length at least 1 expected, length 0 found');
+        errors = validateColorArray({validateSpec: validate, key: 'colorArray', value: ['red'], valueSpec: {'min-length': 1}});
+        expect(errors).toHaveLength(0);
+        errors = validateColorArray({validateSpec: validate, key: 'colorArray', value: ['red', 'red', 'red'], valueSpec: {'min-length': 1}});
+        expect(errors).toHaveLength(0);
+        errors = validateColorArray({validateSpec: validate, key: 'colorArray', value: 'red', valueSpec: {'min-length': 1}});
+        expect(errors).toHaveLength(0);
+        errors = validateColorArray({validateSpec: validate, key: 'colorArray', value: 'red', valueSpec: {'min-length': 2}});
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toBe('colorArray: array length at least 2 expected, length 1 found');
+    });
 });

--- a/src/validate/validate_color_array.ts
+++ b/src/validate/validate_color_array.ts
@@ -1,12 +1,19 @@
+import {ValidationError} from '../error/validation_error';
 import {getType} from '../util/get_type';
 import {validateColor} from './validate_color';
 
 export function validateColorArray(options) {
     const key = options.key;
     const value = options.value;
+    const valueSpec = options.valueSpec;
     const type = getType(value);
 
     if (type === 'array') {
+
+        if (valueSpec && valueSpec['min-length'] && value.length < valueSpec['min-length']) {
+            return [new ValidationError(key, value, `array length at least ${valueSpec['min-length']} expected, length ${value.length} found`)];
+        }
+
         let errors = [];
         for (let i = 0; i < value.length; i++) {
             errors = errors.concat(validateColor({
@@ -17,6 +24,9 @@ export function validateColorArray(options) {
         }
         return errors;
     } else {
+        if (valueSpec && valueSpec['min-length'] && 1 < valueSpec['min-length']) {
+            return [new ValidationError(key, value, `array length at least ${valueSpec['min-length']} expected, length 1 found`)];
+        }
         return validateColor({
             key,
             value,

--- a/src/validate/validate_number_array.test.ts
+++ b/src/validate/validate_number_array.test.ts
@@ -65,4 +65,19 @@ describe('Validate NumberArray', () => {
         errors = validateNumberArray({validateSpec: validate, key: 'numberArray', value: [1, 1, 1, 1, 1, 1, 1, 1]});
         expect(errors).toHaveLength(0);
     });
+
+    test('Should enforce min-length property', () => {
+        let errors = validateNumberArray({validateSpec: validate, key: 'numberArray', value: [], valueSpec: {'min-length': 1}});
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toBe('numberArray: array length at least 1 expected, length 0 found');
+        errors = validateNumberArray({validateSpec: validate, key: 'numberArray', value: [1], valueSpec: {'min-length': 1}});
+        expect(errors).toHaveLength(0);
+        errors = validateNumberArray({validateSpec: validate, key: 'numberArray', value: [1, 1, 1], valueSpec: {'min-length': 1}});
+        expect(errors).toHaveLength(0);
+        errors = validateNumberArray({validateSpec: validate, key: 'numberArray', value: 1, valueSpec: {'min-length': 1}});
+        expect(errors).toHaveLength(0);
+        errors = validateNumberArray({validateSpec: validate, key: 'numberArray', value: 1, valueSpec: {'min-length': 2}});
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toBe('numberArray: array length at least 2 expected, length 1 found');
+    });
 });

--- a/src/validate/validate_number_array.ts
+++ b/src/validate/validate_number_array.ts
@@ -1,9 +1,11 @@
+import {ValidationError} from '../error/validation_error';
 import {getType} from '../util/get_type';
 import {validateNumber} from './validate_number';
 
 export function validateNumberArray(options) {
     const key = options.key;
     const value = options.value;
+    const valueSpec = options.valueSpec;
     const type = getType(value);
 
     if (type === 'array') {
@@ -11,6 +13,10 @@ export function validateNumberArray(options) {
         const arrayElementSpec = {
             type: 'number'
         };
+
+        if (valueSpec && valueSpec['min-length'] && value.length < valueSpec['min-length']) {
+            return [new ValidationError(key, value, `array length at least ${valueSpec['min-length']} expected, length ${value.length} found`)];
+        }
 
         let errors = [];
         for (let i = 0; i < value.length; i++) {
@@ -23,6 +29,9 @@ export function validateNumberArray(options) {
         }
         return errors;
     } else {
+        if (valueSpec && valueSpec['min-length'] && 1 < valueSpec['min-length']) {
+            return [new ValidationError(key, value, `array length at least ${valueSpec['min-length']} expected, length 1 found`)];
+        }
         return validateNumber({
             key,
             value,

--- a/test/integration/style-spec/tests/layers.input.json
+++ b/test/integration/style-spec/tests/layers.input.json
@@ -178,6 +178,18 @@
       "type": "custom",
       "source": "vector",
       "source-layer": "layer"
+    },
+    {
+      "id": "hillshade-empty-numberArray",
+      "type": "hillshade",
+      "source": "raster-dem",
+      "source-layer": "source-layer",
+      "paint": {
+        "hillshade-illumination-direction": [],
+        "hillshade-illumination-altitude": [],
+        "hillshade-highlight-color": [],
+        "hillshade-shadow-color": []
+      }
     }
   ]
 }

--- a/test/integration/style-spec/tests/layers.output.json
+++ b/test/integration/style-spec/tests/layers.output.json
@@ -86,5 +86,21 @@
   {
     "message": "layers[21].type: expected one of [fill, line, symbol, circle, heatmap, fill-extrusion, raster, hillshade, background], \"custom\" found",
     "line": 178
+  },
+  {
+    "message": "layers[22].paint.hillshade-illumination-direction: array length at least 1 expected, length 0 found",
+    "line": 188
+  },
+  {
+    "message": "layers[22].paint.hillshade-illumination-altitude: array length at least 1 expected, length 0 found",
+    "line": 189
+  },
+  {
+    "message": "layers[22].paint.hillshade-highlight-color: array length at least 1 expected, length 0 found",
+    "line": 190
+  },
+  {
+    "message": "layers[22].paint.hillshade-shadow-color: array length at least 1 expected, length 0 found",
+    "line": 191
   }
 ]


### PR DESCRIPTION
This PR amends #1088 by adding `min-length` property to the new types `numberArray` and `colorArray`.

This is used for validating that the hillshade illumination parameters are not empty arrays.

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
