### PR TITLE
validate that colorArrays and numberArrays are non-empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🐞 Bug fixes
 
+- Validate that `numberArray` and `colorArray` values are non-empty ([#1094](https://github.com/maplibre/maplibre-style-spec/pull/1094))
 - _...Add new stuff here..._
 
 ## 23.2.0

--- a/src/validate/validate_color_array.test.ts
+++ b/src/validate/validate_color_array.test.ts
@@ -55,7 +55,8 @@ describe('Validate ColorArray', () => {
 
     test('Should pass if type is array of colors', () => {
         let errors = validateColorArray({validateSpec: validate, key: 'colorArray', value: []});
-        expect(errors).toHaveLength(0);
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toBe('colorArray: array length at least 1 expected, length 0 found');
 
         errors = validateColorArray({validateSpec: validate, key: 'colorArray', value: ['red']});
         expect(errors).toHaveLength(0);

--- a/src/validate/validate_color_array.ts
+++ b/src/validate/validate_color_array.ts
@@ -1,3 +1,4 @@
+import {ValidationError} from '../error/validation_error';
 import {getType} from '../util/get_type';
 import {validateColor} from './validate_color';
 
@@ -7,6 +8,11 @@ export function validateColorArray(options) {
     const type = getType(value);
 
     if (type === 'array') {
+
+        if (value.length < 1) {
+            return [new ValidationError(key, value, 'array length at least 1 expected, length 0 found')];
+        }
+
         let errors = [];
         for (let i = 0; i < value.length; i++) {
             errors = errors.concat(validateColor({

--- a/src/validate/validate_number_array.test.ts
+++ b/src/validate/validate_number_array.test.ts
@@ -57,7 +57,8 @@ describe('Validate NumberArray', () => {
 
     test('Should pass if type is numeric array', () => {
         let errors = validateNumberArray({validateSpec: validate, key: 'numberArray', value: []});
-        expect(errors).toHaveLength(0);
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toBe('numberArray: array length at least 1 expected, length 0 found');
         errors = validateNumberArray({validateSpec: validate, key: 'numberArray', value: [1]});
         expect(errors).toHaveLength(0);
         errors = validateNumberArray({validateSpec: validate, key: 'numberArray', value: [1, 1, 1]});

--- a/src/validate/validate_number_array.ts
+++ b/src/validate/validate_number_array.ts
@@ -1,3 +1,4 @@
+import {ValidationError} from '../error/validation_error';
 import {getType} from '../util/get_type';
 import {validateNumber} from './validate_number';
 
@@ -11,6 +12,10 @@ export function validateNumberArray(options) {
         const arrayElementSpec = {
             type: 'number'
         };
+
+        if (value.length < 1) {
+            return [new ValidationError(key, value, 'array length at least 1 expected, length 0 found')];
+        }
 
         let errors = [];
         for (let i = 0; i < value.length; i++) {

--- a/test/integration/style-spec/tests/layers.input.json
+++ b/test/integration/style-spec/tests/layers.input.json
@@ -178,6 +178,18 @@
       "type": "custom",
       "source": "vector",
       "source-layer": "layer"
+    },
+    {
+      "id": "hillshade-empty-numberArray",
+      "type": "hillshade",
+      "source": "raster-dem",
+      "source-layer": "source-layer",
+      "paint": {
+        "hillshade-illumination-direction": [],
+        "hillshade-illumination-altitude": [],
+        "hillshade-highlight-color": [],
+        "hillshade-shadow-color": []
+      }
     }
   ]
 }

--- a/test/integration/style-spec/tests/layers.output.json
+++ b/test/integration/style-spec/tests/layers.output.json
@@ -86,5 +86,21 @@
   {
     "message": "layers[21].type: expected one of [fill, line, symbol, circle, heatmap, fill-extrusion, raster, hillshade, background], \"custom\" found",
     "line": 178
+  },
+  {
+    "message": "layers[22].paint.hillshade-illumination-direction: array length at least 1 expected, length 0 found",
+    "line": 188
+  },
+  {
+    "message": "layers[22].paint.hillshade-illumination-altitude: array length at least 1 expected, length 0 found",
+    "line": 189
+  },
+  {
+    "message": "layers[22].paint.hillshade-highlight-color: array length at least 1 expected, length 0 found",
+    "line": 190
+  },
+  {
+    "message": "layers[22].paint.hillshade-shadow-color: array length at least 1 expected, length 0 found",
+    "line": 191
   }
 ]


### PR DESCRIPTION
Alternative to #1094.

Validates that `numberArray`s and `colorArray`s are non-empty.

This is used for validating that the hillshade illumination parameters are not empty arrays.

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Write tests for all new functionality.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
