### PR TITLE
docs: unhide nav title element

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -8,7 +8,3 @@
   --md-primary-fg-color: #295DAA;
   --md-accent-fg-color: #568ad6;
 }
-
-.md-nav__title {
-  display: none;
-}


### PR DESCRIPTION
Closes #1097.

Removed the custom styling which hid the `.md-nav__title` element. This allows mobile users to properly navigate up and down the site hierarchy via the sidenav.

https://github.com/user-attachments/assets/7c9ffbd6-f832-4e8f-bd1f-b5bb16fdecf3


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
