### PR TITLE
Fix state validation - no error case

### DIFF
--- a/src/validate/validate_state.test.ts
+++ b/src/validate/validate_state.test.ts
@@ -1,6 +1,11 @@
 import {validateState} from './validate_state';
 
 describe('Validate state', () => {
+    test('Should return no error if type is an object', () => {
+        const errors = validateState({key: 'state', value: {a: 1}});
+        expect(errors).toHaveLength(0);
+    });
+
     test('Should return error if type is not an object', () => {
         const errors = validateState({key: 'state', value: 3});
         expect(errors).toHaveLength(1);

--- a/src/validate/validate_state.ts
+++ b/src/validate/validate_state.ts
@@ -17,4 +17,6 @@ export function validateState(options: ValidateStateOptions) {
             ),
         ];
     }
+
+    return [];
 }

--- a/src/validate/validate_state.ts
+++ b/src/validate/validate_state.ts
@@ -7,7 +7,7 @@ interface ValidateStateOptions {
     value: unknown;
 }
 
-export function validateState(options: ValidateStateOptions) {
+export function validateState(options: ValidateStateOptions): ValidationError[] {
     if (!isObjectLiteral(options.value)) {
         return [
             new ValidationError(


### PR DESCRIPTION
`validateState` should return an empty array when there are no errors, but was incorrectly returning undefined.