### PR TITLE
Improve expression syntax documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
+- Restructure expression syntax documentation ([#1112](https://github.com/maplibre/maplibre-style-spec/pull/1112))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -10,7 +10,7 @@ import jsonStringify from 'json-stringify-pretty-compact';
 const BASE_PATH = 'docs';
 
 type JsonExpressionSyntax = {
-    variants: {
+    overloads: {
         parameters: string[];
         'output-type': string;
     }[];
@@ -140,8 +140,8 @@ function sdkSupportToMarkdown(support: JsonSdkSupport): string {
  */
 function expressionSyntaxToMarkdown(key: string, syntax: JsonExpressionSyntax) {
     let markdown = '\nSyntax:\n';
-    const codeBlockLines = syntax.variants.map((variant) => {
-        return `[${[`"${key}"`, ...variant.parameters].join(', ')}]: ${variant['output-type']}`;
+    const codeBlockLines = syntax.overloads.map((overload) => {
+        return `[${[`"${key}"`, ...overload.parameters].join(', ')}]: ${overload['output-type']}`;
     });
     markdown += `${codeBlockMarkdown(codeBlockLines.join('\n'), 'js')}\n`;
     for (const parameter of syntax.parameters ?? []) {

--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -531,7 +531,8 @@ function createExpressionsContent() {
             const parameterLines = (syntax.parameters ?? []).map((param) => {
                 let line = `- \`${param.name}\``;
                 if (param.type) {
-                    line += `: *${param.type}*`;
+                    const type = param.type.replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+                    line += `: *${type}*`;
                 }
                 if (param.description) {
                     line += ` — ${param.description}`;

--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -512,7 +512,7 @@ function createExpressionsContent() {
             content += `\n### ${key}\n`;
             content += `${value.doc}\n`;
 
-            content += `\nSyntax:\n`;
+            content += '\nSyntax:\n';
             const syntax: {
                 variants: {
                     parameters: string[];

--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -511,9 +511,36 @@ function createExpressionsContent() {
             }
             content += `\n### ${key}\n`;
             content += `${value.doc}\n`;
-            value.example.syntax.method.unshift(`"${key}"`);
-            content += `\nSyntax:\n${codeBlockMarkdown(`[${value.example.syntax.method.join(', ')}]: ${value.example.syntax.result}`, 'js')}\n`;
-            content += `\nExample:\n${codeBlockMarkdown(`"some-property": ${formatJSON(value.example.value)}`)}\n`;
+
+            content += `\nSyntax:\n`;
+            const syntax: {
+                variants: {
+                    parameters: string[];
+                    'output-type': string;
+                }[];
+                parameters?: {
+                    name: string;
+                    type?: string;
+                    description?: string;
+                }[];
+            } = value.syntax;
+            const codeBlockLines = syntax.variants.map((variant) => {
+                return `[${[`"${key}"`, ...variant.parameters].join(', ')}]: ${variant['output-type']}`;
+            });
+            content += `${codeBlockMarkdown(codeBlockLines.join('\n'), 'js')}\n`;
+            const parameterLines = (syntax.parameters ?? []).map((param) => {
+                let line = `- \`${param.name}\``;
+                if (param.type) {
+                    line += `: *${param.type}*`;
+                }
+                if (param.description) {
+                    line += ` — ${param.description}`;
+                }
+                return line;
+            });
+            content += `${parameterLines.join('\n')}\n`;
+
+            content += `\nExample:\n${codeBlockMarkdown(`"some-property": ${formatJSON(value.example)}`)}\n`;
             content += sdkSupportToMarkdown(value['sdk-support'] as any);
             content += '\n';
         }

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -2934,7 +2934,7 @@
         }
       },
       "array": {
-        "doc": "Asserts that the input is an array (optionally with a specific item type and length). If, when the input expression is evaluated, it is not of the asserted type, then this assertion will cause the whole expression to be aborted.",
+        "doc": "Asserts that the input is an array (optionally with a specific item type and length). If, when the input expression is evaluated, it is not of the asserted type or length, then this assertion will cause the whole expression to be aborted.",
         "syntax": {
           "variants": [
             {
@@ -3822,7 +3822,7 @@
         }
       },
       "to-boolean": {
-        "doc": "Converts the input value to a boolean. The result is `false` when then input is an empty string, 0, `false`, `null`, or `NaN`; otherwise it is `true`.",
+        "doc": "Converts the input value to a boolean. The result is `false` when the input is an empty string, 0, `false`, `null`, or `NaN`; otherwise it is `true`.",
         "syntax": {
           "variants": [
             {
@@ -4004,7 +4004,7 @@
         }
       },
       "has": {
-        "doc": "Tests for the presence of an property value in the current feature's properties, or from another object if a second argument is provided.\n\n - [Create and style clusters](https://maplibre.org/maplibre-gl-js/docs/examples/cluster/)",
+        "doc": "Tests for the presence of a property value in the current feature's properties, or from another object if a second argument is provided.\n\n - [Create and style clusters](https://maplibre.org/maplibre-gl-js/docs/examples/cluster/)",
         "syntax": {
           "variants": [
             {

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -2838,7 +2838,7 @@
       "let": {
         "doc": "Binds expressions to named variables, which can then be referenced in the result expression using `[\"var\", \"variable_name\"]`.\n\n - [Visualize population density](https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["var_1_name", "var_1_value", "...", "var_n_name", "var_n_value", "expression"],
               "output-type": "any"
@@ -2875,7 +2875,7 @@
       "var": {
         "doc": "References variable bound using `let`.\n\n - [Visualize population density](https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["var_name"],
               "output-type": "any"
@@ -2902,7 +2902,7 @@
       "literal": {
         "doc": "Provides a literal array or object value.\n\n - [Display and style rich text labels](https://maplibre.org/maplibre-gl-js/docs/examples/display-and-style-rich-text-labels/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["json_object"],
               "output-type": "object"
@@ -2936,7 +2936,7 @@
       "array": {
         "doc": "Asserts that the input is an array (optionally with a specific item type and length). If, when the input expression is evaluated, it is not of the asserted type or length, then this assertion will cause the whole expression to be aborted.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["value"],
               "output-type": "array"
@@ -2980,7 +2980,7 @@
       "at": {
         "doc": "Retrieves an item from an array.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["index", "array"],
               "output-type": "T"
@@ -3012,7 +3012,7 @@
       "in": {
         "doc": "Determines whether an item exists in an array or a substring exists in a string.\n\n - [Measure distances](https://maplibre.org/maplibre-gl-js/docs/examples/measure/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["item", "array"],
               "output-type": "boolean"
@@ -3058,7 +3058,7 @@
       "index-of": {
         "doc": "Returns the first position at which an item can be found in an array or a substring can be found in a string, or `-1` if the input cannot be found. Accepts an optional index from where to begin the search. In a string, a UTF-16 surrogate pair counts as a single position.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["item", "array", "from_index?"],
               "output-type": "number"
@@ -3109,7 +3109,7 @@
       "slice": {
         "doc": "Returns a subarray from an array or a substring from a string from a specified start index, or between a start index and an end index if set. The return value is inclusive of the start index but not of the end index. In a string, a UTF-16 surrogate pair counts as a single position.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["array", "start_index", "end_index?"],
               "output-type": "array<T>"
@@ -3155,7 +3155,7 @@
       "case": {
         "doc": "Selects the first output whose corresponding test condition evaluates to true, or the fallback value otherwise.\n\n - [Create a hover effect](https://maplibre.org/maplibre-gl-js/docs/examples/hover-styles/)\n\n - [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js/docs/examples/cluster-html/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["condition_1", "output_1", "...", "condition_n", "output_n", "fallback"],
               "output-type": "any"
@@ -3190,7 +3190,7 @@
       "match": {
         "doc": "Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `[\"get\", \"building_type\"]`). Each label must be either:\n\n - a single literal value; or\n\n - an array of literal values, whose values must be all strings or all numbers (e.g. `[100, 101]` or `[\"c\", \"b\"]`). The input matches if any of the values in the array matches, similar to the `\"in\"` operator.\n\nEach label must be unique. If the input type does not match the type of the labels, the result will be the fallback value.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input", "label_1", "output_1", "...", "label_n", "output_n", "fallback"],
               "output-type": "any"
@@ -3232,7 +3232,7 @@
       "coalesce": {
         "doc": "Evaluates each expression in turn until the first non-null value is obtained, and returns that value.\n\n - [Use a fallback image](https://maplibre.org/maplibre-gl-js/docs/examples/fallback-image/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["expression_1", "...", "expression_n"],
               "output-type": "any"
@@ -3258,7 +3258,7 @@
       "step": {
         "doc": "Produces discrete, stepped results by evaluating a piecewise-constant function defined by pairs of input and output values (\"stops\"). The `input` may be any numeric expression (e.g., `[\"get\", \"population\"]`). Stop inputs must be numeric literals in strictly ascending order.\n\nReturns the output value of the stop just less than the input, or the first output if the input is less than the first stop.\n\n - [Create and style clusters](https://maplibre.org/maplibre-gl-js/docs/examples/cluster/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input", "output_0", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
               "output-type": "any"
@@ -3300,7 +3300,7 @@
       "interpolate": {
         "doc": "Produces continuous, smooth results by interpolating between pairs of input and output values (\"stops\"). The `input` may be any numeric expression (e.g., `[\"get\", \"population\"]`). Stop inputs must be numeric literals in strictly ascending order. The output type must be `number`, `array<number>`, or `color`.\n\nInterpolation types:\n\n- `[\"linear\"]`, or an expression returning one of those types: Interpolates linearly between the pair of stops just less than and just greater than the input.\n\n- `[\"exponential\", base]`: Interpolates exponentially between the stops just less than and just greater than the input. `base` controls the rate at which the output increases: higher values make the output increase more towards the high end of the range. With values close to 1 the output increases linearly.\n\n- `[\"cubic-bezier\", x1, y1, x2, y2]`: Interpolates using the cubic bezier curve defined by the given control points.\n\n - [Animate map camera around a point](https://maplibre.org/maplibre-gl-js/docs/examples/animate-camera-around-point/)\n\n - [Change building color based on zoom level](https://maplibre.org/maplibre-gl-js/docs/examples/change-building-color-based-on-zoom-level/)\n\n - [Create a heatmap layer](https://maplibre.org/maplibre-gl-js/docs/examples/heatmap-layer/)\n\n - [Visualize population density](https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
               "output-type": "any"
@@ -3342,7 +3342,7 @@
       "interpolate-hcl": {
         "doc": "Produces continuous, smooth results by interpolating between pairs of input and output values (\"stops\"). Works like `interpolate`, but the output type must be `color`, and the interpolation is performed in the Hue-Chroma-Luminance color space.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
               "output-type": "color"
@@ -3380,7 +3380,7 @@
       "interpolate-lab": {
         "doc": "Produces continuous, smooth results by interpolating between pairs of input and output values (\"stops\"). Works like `interpolate`, but the output type must be `color`, and the interpolation is performed in the CIELAB color space.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
               "output-type": "color"
@@ -3418,7 +3418,7 @@
       "ln2": {
         "doc": "Returns the mathematical constant ln(2).",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": [],
               "output-type": "number"
@@ -3438,7 +3438,7 @@
       "pi": {
         "doc": "Returns the mathematical constant pi.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": [],
               "output-type": "number"
@@ -3458,7 +3458,7 @@
       "e": {
         "doc": "Returns the mathematical constant e.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": [],
               "output-type": "number"
@@ -3478,7 +3478,7 @@
       "typeof": {
         "doc": "Returns a string describing the type of the given value.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["value"],
               "output-type": "string"
@@ -3504,7 +3504,7 @@
       "string": {
         "doc": "Asserts that the input value is a string. If multiple values are provided, each one is evaluated in order until a string is obtained. If none of the inputs are strings, the expression is an error.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["value_1", "...", "value_n"],
               "output-type": "string"
@@ -3530,7 +3530,7 @@
       "number": {
         "doc": "Asserts that the input value is a number. If multiple values are provided, each one is evaluated in order until a number is obtained. If none of the inputs are numbers, the expression is an error.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["value_1", "...", "value_n"],
               "output-type": "number"
@@ -3556,7 +3556,7 @@
       "boolean": {
         "doc": "Asserts that the input value is a boolean. If multiple values are provided, each one is evaluated in order until a boolean is obtained. If none of the inputs are booleans, the expression is an error.\n\n - [Create a hover effect](https://maplibre.org/maplibre-gl-js/docs/examples/hover-styles/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["value_1", "...", "value_n"],
               "output-type": "boolean"
@@ -3582,7 +3582,7 @@
       "object": {
         "doc": "Asserts that the input value is an object. If multiple values are provided, each one is evaluated in order until an object is obtained. If none of the inputs are objects, the expression is an error.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["value_1", "...", "value_n"],
               "output-type": "object"
@@ -3608,7 +3608,7 @@
       "collator": {
         "doc": "Returns a `collator` for use in locale-dependent comparison operations. The `case-sensitive` and `diacritic-sensitive` options default to `false`. The `locale` argument specifies the IETF language tag of the locale to use. If none is provided, the default locale is used. If the requested locale is not available, the `collator` will use a system-defined fallback locale. Use `resolved-locale` to test the results of locale fallback behavior.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["options"],
               "output-type": "collator"
@@ -3634,7 +3634,7 @@
       "format": {
         "doc": "Returns a `formatted` string for displaying mixed-format text in the `text-field` property. The input may contain a string literal or expression, including an [`'image'`](#image) expression. Strings may be followed by a style override object that supports the following properties:\n\n- `\"text-font\"`: Overrides the font stack specified by the root layout property.\n\n- `\"text-color\"`: Overrides the color specified by the root paint property.\n\n- `\"font-scale\"`: Applies a scaling factor on `text-size` as specified by the root layout property.\n\n- `\"vertical-align\"`: Aligns vertically text section or image in relation to the row it belongs to. Possible values are: \n\t- `\"bottom\"` *default*: align the bottom of this section with the bottom of other sections.\n<img alt=\"Visual representation of bottom alignment\" src=\"https://github.com/user-attachments/assets/0474a2fd-a4b2-417c-9187-7a13a28695bc\"/>\n\t- `\"center\"`: align the center of this section with the center of other sections.\n<img alt=\"Visual representation of center alignment\" src=\"https://github.com/user-attachments/assets/92237455-be6d-4c5d-b8f6-8127effc1950\"/>\n\t- `\"top\"`: align the top of this section with the top of other sections.\n<img alt=\"Visual representation of top alignment\" src=\"https://github.com/user-attachments/assets/45dccb28-d977-4abb-a006-4ea9792b7c53\"/>\n\t- Refer to [the design proposal](https://github.com/maplibre/maplibre-style-spec/issues/832) for more details.\n\n - [Change the case of labels](https://maplibre.org/maplibre-gl-js/docs/examples/change-case-of-labels/)\n\n - [Display and style rich text labels](https://maplibre.org/maplibre-gl-js/docs/examples/display-and-style-rich-text-labels/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input_1", "style_overrides_1?", "...", "input_n", "style_overrides_n?"],
               "output-type": "formatted"
@@ -3689,7 +3689,7 @@
       "image": {
         "doc": "Returns an `image` type for use in `icon-image`, `*-pattern` entries and as a section in the `format` expression. If set, the `image` argument will check that the requested image exists in the style and will return either the resolved image name or `null`, depending on whether or not the image is currently in the style. This validation process is synchronous and requires the image to have been added to the style before requesting it in the `image` argument.\n\n - [Use a fallback image](https://maplibre.org/maplibre-gl-js/docs/examples/fallback-image/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["image_name"],
               "output-type": "image"
@@ -3716,7 +3716,7 @@
         "doc": "Retrieves a property value from global state that can be set with platform-specific APIs. Defaults can be provided using the [`state`](https://maplibre.org/maplibre-style-spec/root/#state) root property. Returns `null` if no value nor default value is set for the retrieved property.",
         "group": "Lookup",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["property_name"],
               "output-type": "any"
@@ -3742,7 +3742,7 @@
       "number-format": {
         "doc": "Converts the input number into a string representation using the providing formatting rules. If set, the `locale` argument specifies the locale to use, as a BCP 47 language tag. If set, the `currency` argument specifies an ISO 4217 code to use for currency-style formatting. If set, the `min-fraction-digits` and `max-fraction-digits` arguments specify the minimum and maximum number of fractional digits to include.\n\n - [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js/docs/examples/cluster-html/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input", "format_options"],
               "output-type": "string"
@@ -3772,7 +3772,7 @@
       "to-string": {
         "doc": "Converts the input value to a string. If the input is `null`, the result is `\"\"`. If the input is a boolean, the result is `\"true\"` or `\"false\"`. If the input is a number, it is converted to a string as specified by the [\"NumberToString\" algorithm](https://tc39.github.io/ecma262/#sec-tostring-applied-to-the-number-type) of the ECMAScript Language Specification. If the input is a color, it is converted to a string of the form `\"rgba(r,g,b,a)\"`, where `r`, `g`, and `b` are numerals ranging from 0 to 255, and `a` ranges from 0 to 1. Otherwise, the input is converted to a string in the format specified by the [`JSON.stringify`](https://tc39.github.io/ecma262/#sec-json.stringify) function of the ECMAScript Language Specification.\n\n - [Create a time slider](https://maplibre.org/maplibre-gl-js/docs/examples/timeline-animation/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["value"],
               "output-type": "string"
@@ -3798,7 +3798,7 @@
       "to-number": {
         "doc": "Converts the input value to a number, if possible. If the input is `null` or `false`, the result is 0. If the input is `true`, the result is 1. If the input is a string, it is converted to a number as specified by the [\"ToNumber Applied to the String Type\" algorithm](https://tc39.github.io/ecma262/#sec-tonumber-applied-to-the-string-type) of the ECMAScript Language Specification. If multiple values are provided, each one is evaluated in order until the first successful conversion is obtained. If none of the inputs can be converted, the expression is an error.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["value_1", "...", "value_n"],
               "output-type": "number"
@@ -3824,7 +3824,7 @@
       "to-boolean": {
         "doc": "Converts the input value to a boolean. The result is `false` when the input is an empty string, 0, `false`, `null`, or `NaN`; otherwise it is `true`.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["value"],
               "output-type": "boolean"
@@ -3850,7 +3850,7 @@
       "to-rgba": {
         "doc": "Returns a four-element array containing the input color's red, green, blue, and alpha components, in that order.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["color"],
               "output-type": "array"
@@ -3876,7 +3876,7 @@
       "to-color": {
         "doc": "Converts the input value to a color. If multiple values are provided, each one is evaluated in order until the first successful conversion is obtained. If none of the inputs can be converted, the expression is an error.\n\n - [Visualize population density](https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["value_1", "...", "value_n"],
               "output-type": "color"
@@ -3902,7 +3902,7 @@
       "rgb": {
         "doc": "Creates a color value from red, green, and blue components, which must range between 0 and 255, and an alpha component of 1. If any component is out of range, the expression is an error.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["red", "green", "blue"],
               "output-type": "color"
@@ -3936,7 +3936,7 @@
       "rgba": {
         "doc": "Creates a color value from red, green, blue components, which must range between 0 and 255, and an alpha component which must range between 0 and 1. If any component is out of range, the expression is an error.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["red", "green", "blue", "alpha"],
               "output-type": "color"
@@ -3974,7 +3974,7 @@
       "get": {
         "doc": "Retrieves a property value from the current feature's properties, or from another object if a second argument is provided. Returns null if the requested property is missing.\n\n - [Change the case of labels](https://maplibre.org/maplibre-gl-js/docs/examples/change-case-of-labels/)\n\n - [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js/docs/examples/cluster-html/)\n\n - [Extrude polygons for 3D indoor mapping](https://maplibre.org/maplibre-gl-js/docs/examples/3d-extrusion-floorplan/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["property_name", "object?"],
               "output-type": "any"
@@ -4006,7 +4006,7 @@
       "has": {
         "doc": "Tests for the presence of a property value in the current feature's properties, or from another object if a second argument is provided.\n\n - [Create and style clusters](https://maplibre.org/maplibre-gl-js/docs/examples/cluster/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["property_name", "object?"],
               "output-type": "boolean"
@@ -4038,7 +4038,7 @@
       "length": {
         "doc": "Gets the length of an array or string. In a string, a UTF-16 surrogate pair counts as a single position.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["array_or_string"],
               "output-type": "number"
@@ -4064,7 +4064,7 @@
       "properties": {
         "doc": "Gets the feature properties object.  Note that in some cases, it may be more efficient to use [\"get\", \"property_name\"] directly.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": [],
               "output-type": "object"
@@ -4084,7 +4084,7 @@
       "feature-state": {
         "doc": "Retrieves a property value from the current feature's state. Returns null if the requested property is not present on the feature's state. A feature's state is not part of the GeoJSON or vector tile data, and must be set programmatically on each feature. When `source.promoteId` is not provided, features are identified by their `id` attribute, which must be an integer or a string that can be cast to an integer. When `source.promoteId` is provided, features are identified by their `promoteId` property, which may be a number, string, or any primitive data type. Note that [\"feature-state\"] can only be used with paint properties that support data-driven styling.\n\n - [Create a hover effect](https://maplibre.org/maplibre-gl-js/docs/examples/hover-styles/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["property_name"],
               "output-type": "any"
@@ -4110,7 +4110,7 @@
       "geometry-type": {
         "doc": "Returns the feature's simple geometry type: `Point`, `LineString`, or `Polygon`. `MultiPoint`, `MultiLineString`, and `MultiPolygon` are returned as `Point`, `LineString`, and `Polygon`, respectively.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": [],
               "output-type": "string"
@@ -4130,7 +4130,7 @@
       "id": {
         "doc": "Gets the feature's id, if it has one.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": [],
               "output-type": "any"
@@ -4150,7 +4150,7 @@
       "zoom": {
         "doc": "Gets the current zoom level.  Note that in style layout and paint properties, [\"zoom\"] may only appear as the input to a top-level \"step\" or \"interpolate\" expression.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": [],
               "output-type": "number"
@@ -4170,7 +4170,7 @@
       "heatmap-density": {
         "doc": "Gets the kernel density estimation of a pixel in a heatmap layer, which is a relative measure of how many data points are crowded around a particular pixel. Can only be used in the `heatmap-color` property.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": [],
               "output-type": "number"
@@ -4190,7 +4190,7 @@
       "line-progress": {
         "doc": "Gets the progress along a gradient line. Can only be used in the `line-gradient` property.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": [],
               "output-type": "number"
@@ -4210,7 +4210,7 @@
       "accumulated": {
         "doc": "Gets the value of a cluster property accumulated so far. Can only be used in the `clusterProperties` option of a clustered GeoJSON source.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": [],
               "output-type": "any"
@@ -4230,7 +4230,7 @@
       "+": {
         "doc": "Returns the sum of the inputs.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input_1", "...", "input_n"],
               "output-type": "number"
@@ -4256,7 +4256,7 @@
       "*": {
         "doc": "Returns the product of the inputs.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input_1", "...", "input_n"],
               "output-type": "number"
@@ -4282,7 +4282,7 @@
       "-": {
         "doc": "For two inputs, returns the result of subtracting the second input from the first. For a single input, returns the result of subtracting it from 0.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input_1", "input_2"],
               "output-type": "number"
@@ -4323,7 +4323,7 @@
       "/": {
         "doc": "Returns the result of floating point division of the first input by the second.\n\n - [Visualize population density](https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input_1", "input_2"],
               "output-type": "number"
@@ -4355,7 +4355,7 @@
       "%": {
         "doc": "Returns the remainder after integer division of the first input by the second.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input_1", "input_2"],
               "output-type": "number"
@@ -4387,7 +4387,7 @@
       "^": {
         "doc": "Returns the result of raising the first input to the power specified by the second.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input_1", "input_2"],
               "output-type": "number"
@@ -4419,7 +4419,7 @@
       "sqrt": {
         "doc": "Returns the square root of the input.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "number"
@@ -4446,7 +4446,7 @@
       "log10": {
         "doc": "Returns the base-ten logarithm of the input.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "number"
@@ -4472,7 +4472,7 @@
       "ln": {
         "doc": "Returns the natural logarithm of the input.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "number"
@@ -4498,7 +4498,7 @@
       "log2": {
         "doc": "Returns the base-two logarithm of the input.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "number"
@@ -4524,7 +4524,7 @@
       "sin": {
         "doc": "Returns the sine of the input.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "number"
@@ -4550,7 +4550,7 @@
       "cos": {
         "doc": "Returns the cosine of the input.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "number"
@@ -4576,7 +4576,7 @@
       "tan": {
         "doc": "Returns the tangent of the input.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "number"
@@ -4602,7 +4602,7 @@
       "asin": {
         "doc": "Returns the arcsine of the input.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "number"
@@ -4628,7 +4628,7 @@
       "acos": {
         "doc": "Returns the arccosine of the input.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "number"
@@ -4654,7 +4654,7 @@
       "atan": {
         "doc": "Returns the arctangent of the input.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "number"
@@ -4680,7 +4680,7 @@
       "min": {
         "doc": "Returns the minimum value of the inputs.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input_1", "...", "input_n"],
               "output-type": "number"
@@ -4706,7 +4706,7 @@
       "max": {
         "doc": "Returns the maximum value of the inputs.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input_1", "...", "input_n"],
               "output-type": "number"
@@ -4732,7 +4732,7 @@
       "round": {
         "doc": "Rounds the input to the nearest integer. Halfway values are rounded away from zero. For example, `[\"round\", -1.5]` evaluates to -2.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "number"
@@ -4758,7 +4758,7 @@
       "abs": {
         "doc": "Returns the absolute value of the input.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "number"
@@ -4784,7 +4784,7 @@
       "ceil": {
         "doc": "Returns the smallest integer that is greater than or equal to the input.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "number"
@@ -4810,7 +4810,7 @@
       "floor": {
         "doc": "Returns the largest integer that is less than or equal to the input.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "number"
@@ -4836,7 +4836,7 @@
       "distance": {
         "doc": "Returns the shortest distance in meters between the evaluated feature and the input geometry. The input value can be a valid GeoJSON of type `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, `Feature`, or `FeatureCollection`. Distance values returned may vary in precision due to loss in precision from encoding geometries, particularly below zoom level 13.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["geojson"],
               "output-type": "number"
@@ -4862,7 +4862,7 @@
       "==": {
         "doc": "Returns `true` if the input values are equal, `false` otherwise. The comparison is strictly typed: values of different runtime types are always considered unequal. Cases where the types are known to be different at parse time are considered invalid and will produce a parse error. Accepts an optional `collator` argument to control locale-dependent string comparisons.\n\n - [Add multiple geometries from one GeoJSON source](https://maplibre.org/maplibre-gl-js/docs/examples/multiple-geometries/)\n\n - [Create a time slider](https://maplibre.org/maplibre-gl-js/docs/examples/timeline-animation/)\n\n - [Display buildings in 3D](https://maplibre.org/maplibre-gl-js/docs/examples/3d-buildings/)\n\n - [Filter symbols by toggling a list](https://maplibre.org/maplibre-gl-js/docs/examples/filter-markers/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input_1", "input_2", "collator?"],
               "output-type": "boolean"
@@ -4902,7 +4902,7 @@
       "!=": {
         "doc": "Returns `true` if the input values are not equal, `false` otherwise. The comparison is strictly typed: values of different runtime types are always considered unequal. Cases where the types are known to be different at parse time are considered invalid and will produce a parse error. Accepts an optional `collator` argument to control locale-dependent string comparisons.\n\n - [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js/docs/examples/cluster-html/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input_1", "input_2", "collator?"],
               "output-type": "boolean"
@@ -4942,7 +4942,7 @@
       ">": {
         "doc": "Returns `true` if the first input is strictly greater than the second, `false` otherwise. The arguments are required to be either both strings or both numbers; if during evaluation they are not, expression evaluation produces an error. Cases where this constraint is known not to hold at parse time are considered in valid and will produce a parse error. Accepts an optional `collator` argument to control locale-dependent string comparisons.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["string_1", "string_2", "collator?"],
               "output-type": "boolean"
@@ -4986,7 +4986,7 @@
       "<": {
         "doc": "Returns `true` if the first input is strictly less than the second, `false` otherwise. The arguments are required to be either both strings or both numbers; if during evaluation they are not, expression evaluation produces an error. Cases where this constraint is known not to hold at parse time are considered in valid and will produce a parse error. Accepts an optional `collator` argument to control locale-dependent string comparisons.\n\n - [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js/docs/examples/cluster-html/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["string_1", "string_2", "collator?"],
               "output-type": "boolean"
@@ -5030,7 +5030,7 @@
       ">=": {
         "doc": "Returns `true` if the first input is greater than or equal to the second, `false` otherwise. The arguments are required to be either both strings or both numbers; if during evaluation they are not, expression evaluation produces an error. Cases where this constraint is known not to hold at parse time are considered in valid and will produce a parse error. Accepts an optional `collator` argument to control locale-dependent string comparisons.\n\n - [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js/docs/examples/cluster-html/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["string_1", "string_2", "collator?"],
               "output-type": "boolean"
@@ -5074,7 +5074,7 @@
       "<=": {
         "doc": "Returns `true` if the first input is less than or equal to the second, `false` otherwise. The arguments are required to be either both strings or both numbers; if during evaluation they are not, expression evaluation produces an error. Cases where this constraint is known not to hold at parse time are considered in valid and will produce a parse error. Accepts an optional `collator` argument to control locale-dependent string comparisons.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["string_1", "string_2", "collator?"],
               "output-type": "boolean"
@@ -5118,7 +5118,7 @@
       "all": {
         "doc": "Returns `true` if all the inputs are `true`, `false` otherwise. The inputs are evaluated in order, and evaluation is short-circuiting: once an input expression evaluates to `false`, the result is `false` and no further input expressions are evaluated.\n\n - [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js/docs/examples/cluster-html/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input_1", "...", "input_n"],
               "output-type": "boolean"
@@ -5144,7 +5144,7 @@
       "any": {
         "doc": "Returns `true` if any of the inputs are `true`, `false` otherwise. The inputs are evaluated in order, and evaluation is short-circuiting: once an input expression evaluates to `true`, the result is `true` and no further input expressions are evaluated.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input_1", "...", "input_n"],
               "output-type": "boolean"
@@ -5170,7 +5170,7 @@
       "!": {
         "doc": "Logical negation. Returns `true` if the input is `false`, and `false` if the input is `true`.\n\n - [Create and style clusters](https://maplibre.org/maplibre-gl-js/docs/examples/cluster/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "boolean"
@@ -5196,7 +5196,7 @@
       "within": {
         "doc": "Returns `true` if the evaluated feature is fully contained inside a boundary of the input geometry, `false` otherwise. The input value can be a valid GeoJSON of type `Polygon`, `MultiPolygon`, `Feature`, or `FeatureCollection`. Supported features for evaluation:\n\n- `Point`: Returns `false` if a point is on the boundary or falls outside the boundary.\n\n- `LineString`: Returns `false` if any part of a line falls outside the boundary, the line intersects the boundary, or a line's endpoint is on the boundary.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["geojson"],
               "output-type": "boolean"
@@ -5222,7 +5222,7 @@
       "is-supported-script": {
         "doc": "Returns `true` if the input string is expected to render legibly. Returns `false` if the input string contains sections that cannot be rendered without potential loss of meaning (e.g. Indic scripts that require complex text shaping, or right-to-left scripts if the `mapbox-gl-rtl-text` plugin is not in use in MapLibre GL JS).",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "boolean"
@@ -5248,7 +5248,7 @@
       "upcase": {
         "doc": "Returns the input string converted to uppercase. Follows the Unicode Default Case Conversion algorithm and the locale-insensitive case mappings in the Unicode Character Database.\n\n - [Change the case of labels](https://maplibre.org/maplibre-gl-js/docs/examples/change-case-of-labels/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "string"
@@ -5274,7 +5274,7 @@
       "downcase": {
         "doc": "Returns the input string converted to lowercase. Follows the Unicode Default Case Conversion algorithm and the locale-insensitive case mappings in the Unicode Character Database.\n\n - [Change the case of labels](https://maplibre.org/maplibre-gl-js/docs/examples/change-case-of-labels/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input"],
               "output-type": "string"
@@ -5300,7 +5300,7 @@
       "concat": {
         "doc": "Returns a `string` consisting of the concatenation of the inputs. Each input is converted to a string as if by `to-string`.\n\n - [Add a generated icon to the map](https://maplibre.org/maplibre-gl-js/docs/examples/add-image-missing-generated/)\n\n - [Create a time slider](https://maplibre.org/maplibre-gl-js/docs/examples/timeline-animation/)\n\n - [Use a fallback image](https://maplibre.org/maplibre-gl-js/docs/examples/fallback-image/)\n\n - [Variable label placement](https://maplibre.org/maplibre-gl-js/docs/examples/variable-label-placement/)",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["input_1", "...", "input_n"],
               "output-type": "string"
@@ -5326,7 +5326,7 @@
       "resolved-locale": {
         "doc": "Returns the IETF language tag of the locale being used by the provided `collator`. This can be used to determine the default system locale, or to determine if a requested locale was successfully loaded.",
         "syntax": {
-          "variants": [
+          "overloads": [
             {
               "parameters": ["collator"],
               "output-type": "string"

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -2840,10 +2840,6 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["var_1_name", "var_1_value", "expression"],
-              "output-type": "any"
-            },
-            {
               "parameters": ["var_1_name", "var_1_value", "...", "var_n_name", "var_n_value", "expression"],
               "output-type": "any"
             }
@@ -3161,10 +3157,6 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["condition_1", "output_1", "fallback"],
-              "output-type": "any"
-            },
-            {
               "parameters": ["condition_1", "output_1", "...", "condition_n", "output_n", "fallback"],
               "output-type": "any"
             }
@@ -3200,10 +3192,6 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["input", "label_1", "output_1", "fallback"],
-              "output-type": "any"
-            },
-            {
               "parameters": ["input", "label_1", "output_1", "...", "label_n", "output_n", "fallback"],
               "output-type": "any"
             }
@@ -3227,7 +3215,7 @@
             {
               "name": "fallback",
               "type": "any",
-              "description": "The result when no label matches ths input."
+              "description": "The result when no label matches the input."
             }
           ]
         },
@@ -3245,10 +3233,6 @@
         "doc": "Evaluates each expression in turn until the first non-null value is obtained, and returns that value.\n\n - [Use a fallback image](https://maplibre.org/maplibre-gl-js/docs/examples/fallback-image/)",
         "syntax": {
           "variants": [
-            {
-              "parameters": ["expression_1"],
-              "output-type": "any"
-            },
             {
               "parameters": ["expression_1", "...", "expression_n"],
               "output-type": "any"
@@ -3275,10 +3259,6 @@
         "doc": "Produces discrete, stepped results by evaluating a piecewise-constant function defined by pairs of input and output values (\"stops\"). The `input` may be any numeric expression (e.g., `[\"get\", \"population\"]`). Stop inputs must be numeric literals in strictly ascending order.\n\nReturns the output value of the stop just less than the input, or the first output if the input is less than the first stop.\n\n - [Create and style clusters](https://maplibre.org/maplibre-gl-js/docs/examples/cluster/)",
         "syntax": {
           "variants": [
-            {
-              "parameters": ["input", "output_0", "stop_1_input", "stop_1_output"],
-              "output-type": "any"
-            },
             {
               "parameters": ["input", "output_0", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
               "output-type": "any"
@@ -3322,10 +3302,6 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output"],
-              "output-type": "any"
-            },
-            {
               "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
               "output-type": "any"
             }
@@ -3368,10 +3344,6 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output"],
-              "output-type": "color"
-            },
-            {
               "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
               "output-type": "color"
             }
@@ -3409,10 +3381,6 @@
         "doc": "Produces continuous, smooth results by interpolating between pairs of input and output values (\"stops\"). Works like `interpolate`, but the output type must be `color`, and the interpolation is performed in the CIELAB color space.",
         "syntax": {
           "variants": [
-            {
-              "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output"],
-              "output-type": "color"
-            },
             {
               "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
               "output-type": "color"
@@ -3538,21 +3506,13 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value"],
-              "output-type": "string"
-            },
-            {
-              "parameters": ["value", "fallback_1", "...", "fallback_n"],
+              "parameters": ["value_1", "...", "value_n"],
               "output-type": "string"
             }
           ],
           "parameters": [
             {
-              "name": "value",
-              "type": "any"
-            },
-            {
-              "name": "fallback_i",
+              "name": "value_i",
               "type": "any"
             }
           ]
@@ -3572,21 +3532,13 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value"],
-              "output-type": "number"
-            },
-            {
-              "parameters": ["value", "fallback_1", "...", "fallback_n"],
+              "parameters": ["value_1", "...", "value_n"],
               "output-type": "number"
             }
           ],
           "parameters": [
             {
-              "name": "value",
-              "type": "any"
-            },
-            {
-              "name": "fallback_i",
+              "name": "value_i",
               "type": "any"
             }
           ]
@@ -3606,21 +3558,13 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value"],
-              "output-type": "boolean"
-            },
-            {
-              "parameters": ["value", "fallback_1", "...", "fallback_n"],
+              "parameters": ["value_1", "...", "value_n"],
               "output-type": "boolean"
             }
           ],
           "parameters": [
             {
-              "name": "value",
-              "type": "any"
-            },
-            {
-              "name": "fallback_i",
+              "name": "value_i",
               "type": "any"
             }
           ]
@@ -3640,21 +3584,13 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value"],
-              "output-type": "object"
-            },
-            {
-              "parameters": ["value", "fallback_1", "...", "fallback_n"],
+              "parameters": ["value_1", "...", "value_n"],
               "output-type": "object"
             }
           ],
           "parameters": [
             {
-              "name": "value",
-              "type": "any"
-            },
-            {
-              "name": "fallback_i",
+              "name": "value_i",
               "type": "any"
             }
           ]
@@ -3700,11 +3636,7 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["input_1", "options_1?"],
-              "output-type": "formatted"
-            },
-            {
-              "parameters": ["input_1", "options_1?", "...", "input_n", "options_n?"],
+              "parameters": ["input_1", "style_overrides_1?", "...", "input_n", "style_overrides_n?"],
               "output-type": "formatted"
             }
           ],
@@ -3714,7 +3646,7 @@
               "type": "string | image"
             },
             {
-              "name": "options_i",
+              "name": "style_overrides_i",
               "type": "{ \"text-font\"?: string, \"text-color\"?: color, \"font-scale\"?: number, \"vertical-align\"?: \"bottom\" | \"center\" | \"top\" }"
             }
           ]
@@ -3812,17 +3744,17 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number", "options"],
+              "parameters": ["input", "format_options"],
               "output-type": "string"
             }
           ],
           "parameters": [
             {
-              "name": "number",
+              "name": "input",
               "type": "number"
             },
             {
-              "name": "options",
+              "name": "format_options",
               "type": "{ \"locale\"?: string, \"currency\"?: string, \"min-fraction-digits\"?: number, \"max-fraction-digits\"?: number }"
             }
           ]
@@ -3868,21 +3800,13 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value"],
-              "output-type": "number"
-            },
-            {
-              "parameters": ["value", "fallback_1", "...", "fallback_n"],
+              "parameters": ["value_1", "...", "value_n"],
               "output-type": "number"
             }
           ],
           "parameters": [
             {
-              "name": "value",
-              "type": "any"
-            },
-            {
-              "name": "fallback_i",
+              "name": "value_i",
               "type": "any"
             }
           ]
@@ -3954,21 +3878,13 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value"],
-              "output-type": "color"
-            },
-            {
-              "parameters": ["value", "fallback_1", "...", "fallback_n"],
+              "parameters": ["value_1", "...", "value_n"],
               "output-type": "color"
             }
           ],
           "parameters": [
             {
-              "name": "value",
-              "type": "any"
-            },
-            {
-              "name": "fallback_i",
+              "name": "value_i",
               "type": "any"
             }
           ]
@@ -5204,11 +5120,7 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["input_1", "input_2"],
-              "output-type": "boolean"
-            },
-            {
-              "parameters": ["input_1", "input_2", "...", "input_n"],
+              "parameters": ["input_1", "...", "input_n"],
               "output-type": "boolean"
             }
           ],
@@ -5234,11 +5146,7 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["input_1", "input_2"],
-              "output-type": "boolean"
-            },
-            {
-              "parameters": ["input_1", "input_2", "...", "input_n"],
+              "parameters": ["input_1", "...", "input_n"],
               "output-type": "boolean"
             }
           ],

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -2840,8 +2840,29 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["string", "value", "expression"],
-              "output-type": "value"
+              "parameters": ["var_1_name", "var_1_value", "expression"],
+              "output-type": "any"
+            },
+            {
+              "parameters": ["var_1_name", "var_1_value", "...", "var_n_name", "var_n_value", "expression"],
+              "output-type": "any"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "var_i_name",
+              "type": "string literal",
+              "description": "The name of the i-th variable."
+            },
+            {
+              "name": "var_i_value",
+              "type": "any",
+              "description": "The value of the i-th variable."
+            },
+            {
+              "name": "expression",
+              "type": "any",
+              "description": "The expression within which the named variables can be referenced."
             }
           ]
         },
@@ -2860,8 +2881,15 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["string"],
-              "output-type": "value"
+              "parameters": ["var_name"],
+              "output-type": "any"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "var_name",
+              "type": "string literal",
+              "description": "The name of the variable bound using `let`."
             }
           ]
         },
@@ -2880,8 +2908,22 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["JSON object or array"],
-              "output-type": "array | object"
+              "parameters": ["json_object"],
+              "output-type": "object"
+            },
+            {
+              "parameters": ["json_array"],
+              "output-type": "array"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "json_object",
+              "type": "JSON object"
+            },
+            {
+              "name": "json_array",
+              "type": "JSON array"
             }
           ]
         },
@@ -2900,8 +2942,32 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "string?", "number?"],
+              "parameters": ["value"],
               "output-type": "array"
+            },
+            {
+              "parameters": ["type", "value"],
+              "output-type": "array<type>"
+            },
+            {
+              "parameters": ["type", "length", "value"],
+              "output-type": "array<type, length>"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "value",
+              "type": "any"
+            },
+            {
+              "name": "type",
+              "type": "\"string\" | \"number\" | \"boolean\"",
+              "description": "The asserted type of the input array."
+            },
+            {
+              "name": "length",
+              "type": "number literal",
+              "description": "The asserted length of the input array."
             }
           ]
         },
@@ -2920,8 +2986,20 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number", "value"],
-              "output-type": "value"
+              "parameters": ["index", "array"],
+              "output-type": "T"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "index",
+              "type": "number",
+              "description": "The index into `array`."
+            },
+            {
+              "name": "array",
+              "type": "array<T>",
+              "description": "The array of items to retrieve the specified item from."
             }
           ]
         },
@@ -2940,8 +3018,34 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "value"],
+              "parameters": ["item", "array"],
               "output-type": "boolean"
+            },
+            {
+              "parameters": ["substring", "string"],
+              "output-type": "boolean"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "item",
+              "type": "T",
+              "description": "The needle to search for within `array`."
+            },
+            {
+              "name": "array",
+              "type": "array<T>",
+              "description": "The haystack through which to search for `item`."
+            },
+            {
+              "name": "substring",
+              "type": "string",
+              "description": "The needle to search for within `string`."
+            },
+            {
+              "name": "string",
+              "type": "string",
+              "description": "The haystack through which to search for `substring`."
             }
           ]
         },
@@ -2960,8 +3064,39 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "value", "number?"],
+              "parameters": ["item", "array", "from_index?"],
               "output-type": "number"
+            },
+            {
+              "parameters": ["substring", "string", "from_index?"],
+              "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "item",
+              "type": "T",
+              "description": "The needle to search for within `array`."
+            },
+            {
+              "name": "array",
+              "type": "array<T>",
+              "description": "The haystack through which to search for `item`."
+            },
+            {
+              "name": "substring",
+              "type": "string",
+              "description": "The needle to search for within `string`."
+            },
+            {
+              "name": "string",
+              "type": "string",
+              "description": "The haystack through which to search for `substring`."
+            },
+            {
+              "name": "from_index",
+              "type": "number",
+              "description": "The index from where to begin the search."
             }
           ]
         },
@@ -2976,12 +3111,38 @@
         }
       },
       "slice": {
-        "doc": "Returns an item from an array or a substring from a string from a specified start index, or between a start index and an end index if set. The return value is inclusive of the start index but not of the end index. In a string, a UTF-16 surrogate pair counts as a single position.",
+        "doc": "Returns a subarray from an array or a substring from a string from a specified start index, or between a start index and an end index if set. The return value is inclusive of the start index but not of the end index. In a string, a UTF-16 surrogate pair counts as a single position.",
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "number", "number?"],
-              "output-type": "value"
+              "parameters": ["array", "start_index", "end_index?"],
+              "output-type": "array<T>"
+            },
+            {
+              "parameters": ["string", "start_index", "end_index?"],
+              "output-type": "string"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "array",
+              "type": "array<T>",
+              "description": "The original array from which to extract the subarray."
+            },
+            {
+              "name": "string",
+              "type": "string",
+              "description": "The original string from which to extract the substring."
+            },
+            {
+              "name": "start_index",
+              "type": "number",
+              "description": "The inclusive index from which `slice` extracts items or characters from the subarray or substring."
+            },
+            {
+              "name": "end_index",
+              "type": "number",
+              "description": "The non-inclusive index up to which `slice` extracts items or characters from the subarray or substring."
             }
           ]
         },
@@ -3000,8 +3161,27 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "value", "...", "fallback: value"],
-              "output-type": "value"
+              "parameters": ["condition_1", "output_1", "fallback"],
+              "output-type": "any"
+            },
+            {
+              "parameters": ["condition_1", "output_1", "...", "condition_n", "output_n", "fallback"],
+              "output-type": "any"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "condition_i",
+              "type": "boolean"
+            },
+            {
+              "name": "output_i",
+              "type": "any"
+            },
+            {
+              "name": "fallback",
+              "type": "any",
+              "description": "The result when no condition evaluates to true."
             }
           ]
         },
@@ -3020,8 +3200,34 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "value", "...", "fallback: value"],
-              "output-type": "value"
+              "parameters": ["input", "label_1", "output_1", "fallback"],
+              "output-type": "any"
+            },
+            {
+              "parameters": ["input", "label_1", "output_1", "...", "label_n", "output_n", "fallback"],
+              "output-type": "any"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "any",
+              "description": "Any expression."
+            },
+            {
+              "name": "label_i",
+              "type": "string literal | array<string literal> | array<number literal>",
+              "description": "The i-th literal value or array of literal values to match the input against."
+            },
+            {
+              "name": "output_i",
+              "type": "any",
+              "description": "The result when the i-th label is the first label to match the input."
+            },
+            {
+              "name": "fallback",
+              "type": "any",
+              "description": "The result when no label matches ths input."
             }
           ]
         },
@@ -3040,8 +3246,18 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["coalesce", "value", "fallback"],
-              "output-type": "value"
+              "parameters": ["expression_1"],
+              "output-type": "any"
+            },
+            {
+              "parameters": ["expression_1", "...", "expression_n"],
+              "output-type": "any"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "expression_i",
+              "type": "any"
             }
           ]
         },
@@ -3060,8 +3276,34 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["step", "input1", "output1", "input2", "output2", "..."],
-              "output-type": "number"
+              "parameters": ["input", "output_0", "stop_1_input", "stop_1_output"],
+              "output-type": "any"
+            },
+            {
+              "parameters": ["input", "output_0", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
+              "output-type": "any"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "number",
+              "description": "Any numeric expression."
+            },
+            {
+              "name": "output_0",
+              "type": "any",
+              "description": "The result when the `input` is less than the first stop."
+            },
+            {
+              "name": "stop_i_input",
+              "type": "number literal",
+              "description": "The value of the i-th stop against which the `input` is compared."
+            },
+            {
+              "name": "stop_i_output",
+              "type": "any",
+              "description": "The result when the i-th stop is the last stop less than the `input`."
             }
           ]
         },
@@ -3080,8 +3322,34 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["[\"linear\"] | [\"exponential\", base] | [\"cubic-bezier\", x1, y1, x2, y2]", "input1", "output1", "input2", "output2", "..."],
-              "output-type": "number | array<number> | color"
+              "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output"],
+              "output-type": "any"
+            },
+            {
+              "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
+              "output-type": "any"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "interpolation_type",
+              "type": "[\"linear\"] | [\"exponential\", base] | [\"cubic-bezier\", x1, y1, x2, y2]",
+              "description": "The interpolation type."
+            },
+            {
+              "name": "input",
+              "type": "number",
+              "description": "Any numeric expression."
+            },
+            {
+              "name": "stop_i_input",
+              "type": "number literal",
+              "description": "The value of the i-th stop against which the `input` is compared."
+            },
+            {
+              "name": "stop_i_output",
+              "type": "number | array<number> | color",
+              "description": "The output value corresponding to the i-th stop."
             }
           ]
         },
@@ -3100,8 +3368,30 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["[\"linear\"] | [\"exponential\", base] | [\"cubic-bezier\", x1, y1, x2, y2]", "input1", "output1", "input2", "output2", "..."],
+              "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output"],
               "output-type": "color"
+            },
+            {
+              "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
+              "output-type": "color"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "interpolation_type",
+              "type": "[\"linear\"] | [\"exponential\", base] | [\"cubic-bezier\", x1, y1, x2, y2]"
+            },
+            {
+              "name": "input",
+              "type": "number"
+            },
+            {
+              "name": "stop_i_input",
+              "type": "number literal"
+            },
+            {
+              "name": "stop_i_output",
+              "type": "color"
             }
           ]
         },
@@ -3120,8 +3410,30 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["[\"linear\"] | [\"exponential\", base] | [\"cubic-bezier\", x1, y1, x2, y2]", "input1", "output1", "input2", "output2", "..."],
+              "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output"],
               "output-type": "color"
+            },
+            {
+              "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
+              "output-type": "color"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "interpolation_type",
+              "type": "[\"linear\"] | [\"exponential\", base] | [\"cubic-bezier\", x1, y1, x2, y2]"
+            },
+            {
+              "name": "input",
+              "type": "number"
+            },
+            {
+              "name": "stop_i_input",
+              "type": "number literal"
+            },
+            {
+              "name": "stop_i_output",
+              "type": "color"
             }
           ]
         },
@@ -3136,7 +3448,7 @@
         }
       },
       "ln2": {
-        "doc": "Returns mathematical constant ln(2).",
+        "doc": "Returns the mathematical constant ln(2).",
         "syntax": {
           "variants": [
             {
@@ -3203,6 +3515,12 @@
               "parameters": ["value"],
               "output-type": "string"
             }
+          ],
+          "parameters": [
+            {
+              "name": "value",
+              "type": "any"
+            }
           ]
         },
         "example": ["typeof", ["get", "name"]],
@@ -3220,8 +3538,22 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "fallback: value", "fallback: value", "..."],
+              "parameters": ["value"],
               "output-type": "string"
+            },
+            {
+              "parameters": ["value", "fallback_1", "...", "fallback_n"],
+              "output-type": "string"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "value",
+              "type": "any"
+            },
+            {
+              "name": "fallback_i",
+              "type": "any"
             }
           ]
         },
@@ -3240,8 +3572,22 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "fallback: value", "fallback: value", "..."],
+              "parameters": ["value"],
               "output-type": "number"
+            },
+            {
+              "parameters": ["value", "fallback_1", "...", "fallback_n"],
+              "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "value",
+              "type": "any"
+            },
+            {
+              "name": "fallback_i",
+              "type": "any"
             }
           ]
         },
@@ -3260,8 +3606,22 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "fallback: value", "fallback: value", "..."],
+              "parameters": ["value"],
               "output-type": "boolean"
+            },
+            {
+              "parameters": ["value", "fallback_1", "...", "fallback_n"],
+              "output-type": "boolean"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "value",
+              "type": "any"
+            },
+            {
+              "name": "fallback_i",
+              "type": "any"
             }
           ]
         },
@@ -3280,8 +3640,22 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "fallback: value", "fallback: value", "..."],
+              "parameters": ["value"],
               "output-type": "object"
+            },
+            {
+              "parameters": ["value", "fallback_1", "...", "fallback_n"],
+              "output-type": "object"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "value",
+              "type": "any"
+            },
+            {
+              "name": "fallback_i",
+              "type": "any"
             }
           ]
         },
@@ -3300,8 +3674,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["collator", "{ \"case-sensitive\": boolean, \"diacritic-sensitive\": boolean, \"locale\": string }"],
+              "parameters": ["options"],
               "output-type": "collator"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{ \"case-sensitive\"?: boolean, \"diacritic-sensitive\"?: boolean, \"locale\"?: string }"
             }
           ]
         },
@@ -3320,8 +3700,22 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "{ \"text-font\": string, \"text-color\": color, \"font-scale\": number, \"vertical-align\": \"bottom\" | \"center\" | \"top\" }", "..."],
+              "parameters": ["input_1", "options_1?"],
               "output-type": "formatted"
+            },
+            {
+              "parameters": ["input_1", "options_1?", "...", "input_n", "options_n?"],
+              "output-type": "formatted"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input_i",
+              "type": "string | image"
+            },
+            {
+              "name": "options_i",
+              "type": "{ \"text-font\"?: string, \"text-color\"?: color, \"font-scale\"?: number, \"vertical-align\"?: \"bottom\" | \"center\" | \"top\" }"
             }
           ]
         },
@@ -3365,8 +3759,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value"],
+              "parameters": ["image_name"],
               "output-type": "image"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "image_name",
+              "type": "string"
             }
           ]
         },
@@ -3386,8 +3786,15 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["string"],
-              "output-type": "value"
+              "parameters": ["property_name"],
+              "output-type": "any"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "property_name",
+              "type": "string literal",
+              "description": "The name of the global state property to retrieve."
             }
           ]
         },
@@ -3405,8 +3812,18 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number", "{ \"locale\": string, \"currency\": string, \"min-fraction-digits\": number, \"max-fraction-digits\": number }"],
+              "parameters": ["number", "options"],
               "output-type": "string"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "number",
+              "type": "number"
+            },
+            {
+              "name": "options",
+              "type": "{ \"locale\"?: string, \"currency\"?: string, \"min-fraction-digits\"?: number, \"max-fraction-digits\"?: number }"
             }
           ]
         },
@@ -3428,6 +3845,12 @@
               "parameters": ["value"],
               "output-type": "string"
             }
+          ],
+          "parameters": [
+            {
+              "name": "value",
+              "type": "any"
+            }
           ]
         },
         "example": ["to-string", ["get", "mag"]],
@@ -3445,8 +3868,22 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "fallback: value", "fallback: value", "..."],
+              "parameters": ["value"],
               "output-type": "number"
+            },
+            {
+              "parameters": ["value", "fallback_1", "...", "fallback_n"],
+              "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "value",
+              "type": "any"
+            },
+            {
+              "name": "fallback_i",
+              "type": "any"
             }
           ]
         },
@@ -3468,6 +3905,12 @@
               "parameters": ["value"],
               "output-type": "boolean"
             }
+          ],
+          "parameters": [
+            {
+              "name": "value",
+              "type": "any"
+            }
           ]
         },
         "example": ["to-boolean", "someProperty"],
@@ -3488,6 +3931,12 @@
               "parameters": ["color"],
               "output-type": "array"
             }
+          ],
+          "parameters": [
+            {
+              "name": "color",
+              "type": "color"
+            }
           ]
         },
         "example": ["to-rgba", "#ff0000"],
@@ -3505,8 +3954,22 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "fallback: value", "fallback: value", "..."],
+              "parameters": ["value"],
               "output-type": "color"
+            },
+            {
+              "parameters": ["value", "fallback_1", "...", "fallback_n"],
+              "output-type": "color"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "value",
+              "type": "any"
+            },
+            {
+              "name": "fallback_i",
+              "type": "any"
             }
           ]
         },
@@ -3525,8 +3988,22 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number", "number", "number"],
+              "parameters": ["red", "green", "blue"],
               "output-type": "color"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "red",
+              "type": "number"
+            },
+            {
+              "name": "green",
+              "type": "number"
+            },
+            {
+              "name": "blue",
+              "type": "number"
             }
           ]
         },
@@ -3545,8 +4022,26 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number", "number", "number", "number"],
+              "parameters": ["red", "green", "blue", "alpha"],
               "output-type": "color"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "red",
+              "type": "number"
+            },
+            {
+              "name": "green",
+              "type": "number"
+            },
+            {
+              "name": "blue",
+              "type": "number"
+            },
+            {
+              "name": "alpha",
+              "type": "number"
             }
           ]
         },
@@ -3565,8 +4060,20 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["string"],
-              "output-type": "value"
+              "parameters": ["property_name", "object?"],
+              "output-type": "any"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "property_name",
+              "type": "string",
+              "description": "The name of the property to retrieve the value of."
+            },
+            {
+              "name": "object",
+              "type": "object",
+              "description": "The object to retrieve the value from."
             }
           ]
         },
@@ -3585,8 +4092,20 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["string"],
+              "parameters": ["property_name", "object?"],
               "output-type": "boolean"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "property_name",
+              "type": "string",
+              "description": "The name of the property to test for the presence of."
+            },
+            {
+              "name": "object",
+              "type": "object",
+              "description": "The object in which to test for the presence of the `property_name` property."
             }
           ]
         },
@@ -3605,8 +4124,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["array"],
+              "parameters": ["array_or_string"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "array_or_string",
+              "type": "array | string"
             }
           ]
         },
@@ -3626,7 +4151,7 @@
           "variants": [
             {
               "parameters": [],
-              "output-type": "value"
+              "output-type": "object"
             }
           ]
         },
@@ -3645,8 +4170,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["string"],
-              "output-type": "value"
+              "parameters": ["property_name"],
+              "output-type": "any"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "property_name",
+              "type": "string"
             }
           ]
         },
@@ -3686,7 +4217,7 @@
           "variants": [
             {
               "parameters": [],
-              "output-type": "value"
+              "output-type": "any"
             }
           ]
         },
@@ -3745,12 +4276,12 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number"],
+              "parameters": [],
               "output-type": "number"
             }
           ]
         },
-        "example": ["line-progress", 0.5],
+        "example": ["line-progress"],
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {
@@ -3765,12 +4296,12 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["string"],
-              "output-type": "value"
+              "parameters": [],
+              "output-type": "any"
             }
           ]
         },
-        "example": ["accumulated", "sum"],
+        "example": ["accumulated"],
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {
@@ -3785,8 +4316,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number", "number", "..."],
+              "parameters": ["input_1", "...", "input_n"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input_i",
+              "type": "number"
             }
           ]
         },
@@ -3805,8 +4342,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number", "number", "..."],
+              "parameters": ["input_1", "...", "input_n"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input_i",
+              "type": "number"
             }
           ]
         },
@@ -3825,8 +4368,29 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number", "number?"],
+              "parameters": ["input_1", "input_2"],
               "output-type": "number"
+            },
+            {
+              "parameters": ["single_input"],
+              "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input_1",
+              "type": "number",
+              "description": "The number from which to subtract `input_2`."
+            },
+            {
+              "name": "input_2",
+              "type": "number",
+              "description": "The number to subtract from `input_1`."
+            },
+            {
+              "name": "single_input",
+              "type": "number",
+              "description": "The number to subtract from 0."
             }
           ]
         },
@@ -3845,8 +4409,20 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number", "number"],
+              "parameters": ["input_1", "input_2"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input_1",
+              "type": "number",
+              "description": "The dividend."
+            },
+            {
+              "name": "input_2",
+              "type": "number",
+              "description": "The divisor."
             }
           ]
         },
@@ -3865,8 +4441,20 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number", "number"],
+              "parameters": ["input_1", "input_2"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input_1",
+              "type": "number",
+              "description": "The dividend."
+            },
+            {
+              "name": "input_2",
+              "type": "number",
+              "description": "The divisor."
             }
           ]
         },
@@ -3885,8 +4473,20 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number", "number"],
+              "parameters": ["input_1", "input_2"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input_1",
+              "type": "number",
+              "description": "The base."
+            },
+            {
+              "name": "input_2",
+              "type": "number",
+              "description": "The exponent."
             }
           ]
         },
@@ -3905,8 +4505,15 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number"],
+              "parameters": ["input"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "number",
+              "description": "The radicand."
             }
           ]
         },
@@ -3925,8 +4532,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number"],
+              "parameters": ["input"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "number"
             }
           ]
         },
@@ -3945,8 +4558,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number"],
+              "parameters": ["input"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "number"
             }
           ]
         },
@@ -3965,8 +4584,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number"],
+              "parameters": ["input"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "number"
             }
           ]
         },
@@ -3985,8 +4610,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number"],
+              "parameters": ["input"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "number"
             }
           ]
         },
@@ -4005,8 +4636,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number"],
+              "parameters": ["input"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "number"
             }
           ]
         },
@@ -4025,8 +4662,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number"],
+              "parameters": ["input"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "number"
             }
           ]
         },
@@ -4045,8 +4688,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number"],
+              "parameters": ["input"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "number"
             }
           ]
         },
@@ -4065,8 +4714,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number"],
+              "parameters": ["input"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "number"
             }
           ]
         },
@@ -4085,8 +4740,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number"],
+              "parameters": ["input"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "number"
             }
           ]
         },
@@ -4105,8 +4766,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number", "number", "..."],
+              "parameters": ["input_1", "...", "input_n"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input_i",
+              "type": "number"
             }
           ]
         },
@@ -4125,8 +4792,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number", "number", "..."],
+              "parameters": ["input_1", "...", "input_n"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input_i",
+              "type": "number"
             }
           ]
         },
@@ -4145,8 +4818,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number"],
+              "parameters": ["input"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "number"
             }
           ]
         },
@@ -4165,8 +4844,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number"],
+              "parameters": ["input"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "number"
             }
           ]
         },
@@ -4185,8 +4870,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number"],
+              "parameters": ["input"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "number"
             }
           ]
         },
@@ -4205,8 +4896,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["number"],
+              "parameters": ["input"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "number"
             }
           ]
         },
@@ -4225,8 +4922,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["GeoJSON geometry"],
+              "parameters": ["geojson"],
               "output-type": "number"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "geojson",
+              "type": "GeoJSON object"
             }
           ]
         },
@@ -4245,8 +4948,23 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "value", "collator?"],
+              "parameters": ["input_1", "input_2", "collator?"],
               "output-type": "boolean"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input_1",
+              "type": "any"
+            },
+            {
+              "name": "input_2",
+              "type": "any"
+            },
+            {
+              "name": "collator",
+              "type": "collator",
+              "description": "Options for locale-dependent comparison."
             }
           ]
         },
@@ -4270,8 +4988,23 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "value", "collator?"],
+              "parameters": ["input_1", "input_2", "collator?"],
               "output-type": "boolean"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input_1",
+              "type": "any"
+            },
+            {
+              "name": "input_2",
+              "type": "any"
+            },
+            {
+              "name": "collator",
+              "type": "collator",
+              "description": "Options for locale-dependent comparison."
             }
           ]
         },
@@ -4295,8 +5028,27 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "value", "collator?"],
+              "parameters": ["string_1", "string_2", "collator?"],
               "output-type": "boolean"
+            },
+            {
+              "parameters": ["number_1", "number_2", "collator?"],
+              "output-type": "boolean"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "string_i",
+              "type": "string"
+            },
+            {
+              "name": "number_i",
+              "type": "number"
+            },
+            {
+              "name": "collator",
+              "type": "collator",
+              "description": "Options for locale-dependent comparison."
             }
           ]
         },
@@ -4320,8 +5072,27 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "value", "collator?"],
+              "parameters": ["string_1", "string_2", "collator?"],
               "output-type": "boolean"
+            },
+            {
+              "parameters": ["number_1", "number_2", "collator?"],
+              "output-type": "boolean"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "string_i",
+              "type": "string"
+            },
+            {
+              "name": "number_i",
+              "type": "number"
+            },
+            {
+              "name": "collator",
+              "type": "collator",
+              "description": "Options for locale-dependent comparison."
             }
           ]
         },
@@ -4345,8 +5116,27 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "value", "collator?"],
+              "parameters": ["string_1", "string_2", "collator?"],
               "output-type": "boolean"
+            },
+            {
+              "parameters": ["number_1", "number_2", "collator?"],
+              "output-type": "boolean"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "string_i",
+              "type": "string"
+            },
+            {
+              "name": "number_i",
+              "type": "number"
+            },
+            {
+              "name": "collator",
+              "type": "collator",
+              "description": "Options for locale-dependent comparison."
             }
           ]
         },
@@ -4370,8 +5160,27 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "value", "collator?"],
+              "parameters": ["string_1", "string_2", "collator?"],
               "output-type": "boolean"
+            },
+            {
+              "parameters": ["number_1", "number_2", "collator?"],
+              "output-type": "boolean"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "string_i",
+              "type": "string"
+            },
+            {
+              "name": "number_i",
+              "type": "number"
+            },
+            {
+              "name": "collator",
+              "type": "collator",
+              "description": "Options for locale-dependent comparison."
             }
           ]
         },
@@ -4395,8 +5204,18 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["boolean", "boolean", "..."],
+              "parameters": ["input_1", "input_2"],
               "output-type": "boolean"
+            },
+            {
+              "parameters": ["input_1", "input_2", "...", "input_n"],
+              "output-type": "boolean"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input_i",
+              "type": "boolean"
             }
           ]
         },
@@ -4415,8 +5234,18 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["boolean", "boolean", "..."],
+              "parameters": ["input_1", "input_2"],
               "output-type": "boolean"
+            },
+            {
+              "parameters": ["input_1", "input_2", "...", "input_n"],
+              "output-type": "boolean"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input_i",
+              "type": "boolean"
             }
           ]
         },
@@ -4435,8 +5264,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["value", "value", "collator?"],
+              "parameters": ["input"],
               "output-type": "boolean"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "boolean"
             }
           ]
         },
@@ -4455,8 +5290,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["GeoJSON geometry"],
+              "parameters": ["geojson"],
               "output-type": "boolean"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "geojson",
+              "type": "GeoJSON object"
             }
           ]
         },
@@ -4475,8 +5316,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["string"],
+              "parameters": ["input"],
               "output-type": "boolean"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "string"
             }
           ]
         },
@@ -4495,8 +5342,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["string"],
+              "parameters": ["input"],
               "output-type": "string"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "string"
             }
           ]
         },
@@ -4515,8 +5368,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["string"],
+              "parameters": ["input"],
               "output-type": "string"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input",
+              "type": "string"
             }
           ]
         },
@@ -4535,8 +5394,14 @@
         "syntax": {
           "variants": [
             {
-              "parameters": ["string", "string", "..."],
+              "parameters": ["input_1", "...", "input_n"],
               "output-type": "string"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "input_i",
+              "type": "any"
             }
           ]
         },
@@ -4557,6 +5422,12 @@
             {
               "parameters": ["collator"],
               "output-type": "string"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "collator",
+              "type": "collator"
             }
           ]
         },

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -2837,13 +2837,15 @@
     "values": {
       "let": {
         "doc": "Binds expressions to named variables, which can then be referenced in the result expression using `[\"var\", \"variable_name\"]`.\n\n - [Visualize population density](https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/)",
-        "example": {
-          "syntax": {
-            "method": ["string", "value", "expression"],
-            "result": "value"
-          },
-          "value": ["let", "someNumber", 500, ["interpolate", ["linear"], ["var", "someNumber"], 274, "#edf8e9", 1551, "#006d2c"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["string", "value", "expression"],
+              "output-type": "value"
+            }
+          ]
         },
+        "example": ["let", "someNumber", 500, ["interpolate", ["linear"], ["var", "someNumber"], 274, "#edf8e9", 1551, "#006d2c"]],
         "group": "Variable binding",
         "sdk-support": {
           "basic functionality": {
@@ -2855,13 +2857,15 @@
       },
       "var": {
         "doc": "References variable bound using `let`.\n\n - [Visualize population density](https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/)",
-        "example": {
-          "syntax": {
-            "method": ["string"],
-            "result": "value"
-          },
-          "value": ["var", "density"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["string"],
+              "output-type": "value"
+            }
+          ]
         },
+        "example": ["var", "density"],
         "group": "Variable binding",
         "sdk-support": {
           "basic functionality": {
@@ -2873,13 +2877,15 @@
       },
       "literal": {
         "doc": "Provides a literal array or object value.\n\n - [Display and style rich text labels](https://maplibre.org/maplibre-gl-js/docs/examples/display-and-style-rich-text-labels/)",
-        "example": {
-          "syntax": {
-            "method": ["JSON object or array"],
-            "result": "array | object"
-          },
-          "value": ["literal",["DIN Offc Pro Italic", "Arial Unicode MS Regular"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["JSON object or array"],
+              "output-type": "array | object"
+            }
+          ]
         },
+        "example": ["literal", ["DIN Offc Pro Italic", "Arial Unicode MS Regular"]],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -2891,13 +2897,15 @@
       },
       "array": {
         "doc": "Asserts that the input is an array (optionally with a specific item type and length). If, when the input expression is evaluated, it is not of the asserted type, then this assertion will cause the whole expression to be aborted.",
-        "example": {
-          "syntax": {
-            "method": ["value", "string?", "number?"],
-            "result": "array"
-          },
-          "value": ["array", ["literal", ["a", "b", "c"]], "string", 3]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "string?", "number?"],
+              "output-type": "array"
+            }
+          ]
         },
+        "example": ["array", ["literal", ["a", "b", "c"]], "string", 3],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -2909,13 +2917,15 @@
       },
       "at": {
         "doc": "Retrieves an item from an array.",
-        "example": {
-          "syntax": {
-            "method": ["number", "value"],
-            "result": "value"
-          },
-          "value": ["at", 1, ["literal", ["a", "b", "c"]]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number", "value"],
+              "output-type": "value"
+            }
+          ]
         },
+        "example": ["at", 1, ["literal", ["a", "b", "c"]]],
         "group": "Lookup",
         "sdk-support": {
           "basic functionality": {
@@ -2927,13 +2937,15 @@
       },
       "in": {
         "doc": "Determines whether an item exists in an array or a substring exists in a string.\n\n - [Measure distances](https://maplibre.org/maplibre-gl-js/docs/examples/measure/)",
-        "example": {
-          "syntax": {
-            "method": ["value", "value"],
-            "result": "boolean"
-          },
-          "value": ["in", "$type", "Point"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "value"],
+              "output-type": "boolean"
+            }
+          ]
         },
+        "example": ["in", "$type", "Point"],
         "group": "Lookup",
         "sdk-support": {
           "basic functionality": {
@@ -2945,13 +2957,15 @@
       },
       "index-of": {
         "doc": "Returns the first position at which an item can be found in an array or a substring can be found in a string, or `-1` if the input cannot be found. Accepts an optional index from where to begin the search. In a string, a UTF-16 surrogate pair counts as a single position.",
-        "example": {
-          "syntax": {
-            "method": ["value", "value", "number?"],
-            "result": "number"
-          },
-          "value": ["index-of", "foo", ["baz", "bar", "hello", "foo", "world"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "value", "number?"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["index-of", "foo", ["baz", "bar", "hello", "foo", "world"]],
         "group": "Lookup",
         "sdk-support": {
           "basic functionality": {
@@ -2963,13 +2977,15 @@
       },
       "slice": {
         "doc": "Returns an item from an array or a substring from a string from a specified start index, or between a start index and an end index if set. The return value is inclusive of the start index but not of the end index. In a string, a UTF-16 surrogate pair counts as a single position.",
-        "example": {
-          "syntax": {
-            "method": ["value", "number", "number?"],
-            "result": "value"
-          },
-          "value": ["slice", ["get", "name"], 0, 3]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "number", "number?"],
+              "output-type": "value"
+            }
+          ]
         },
+        "example": ["slice", ["get", "name"], 0, 3],
         "group": "Lookup",
         "sdk-support": {
           "basic functionality": {
@@ -2981,13 +2997,15 @@
       },
       "case": {
         "doc": "Selects the first output whose corresponding test condition evaluates to true, or the fallback value otherwise.\n\n - [Create a hover effect](https://maplibre.org/maplibre-gl-js/docs/examples/hover-styles/)\n\n - [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js/docs/examples/cluster-html/)",
-        "example": {
-          "syntax": {
-            "method": ["value", "value", "...", "fallback: value"],
-            "result": "value"
-          },
-          "value": ["case", ["boolean", ["feature-state", "hover"], false], 1, 0.5 ]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "value", "...", "fallback: value"],
+              "output-type": "value"
+            }
+          ]
         },
+        "example": ["case", ["boolean", ["feature-state", "hover"], false], 1, 0.5],
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -2999,13 +3017,15 @@
       },
       "match": {
         "doc": "Selects the output whose label value matches the input value, or the fallback value if no match is found. The input can be any expression (e.g. `[\"get\", \"building_type\"]`). Each label must be either:\n\n - a single literal value; or\n\n - an array of literal values, whose values must be all strings or all numbers (e.g. `[100, 101]` or `[\"c\", \"b\"]`). The input matches if any of the values in the array matches, similar to the `\"in\"` operator.\n\nEach label must be unique. If the input type does not match the type of the labels, the result will be the fallback value.",
-        "example": {
-          "syntax": {
-            "method": ["value", "value", "...", "fallback: value"],
-            "result": "value"
-          },
-          "value": ["match", ["get", "building_type"], "residential", "#f00", "commercial", "#0f0", "#000"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "value", "...", "fallback: value"],
+              "output-type": "value"
+            }
+          ]
         },
+        "example": ["match", ["get", "building_type"], "residential", "#f00", "commercial", "#0f0", "#000"],
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -3017,13 +3037,15 @@
       },
       "coalesce": {
         "doc": "Evaluates each expression in turn until the first non-null value is obtained, and returns that value.\n\n - [Use a fallback image](https://maplibre.org/maplibre-gl-js/docs/examples/fallback-image/)",
-        "example": {
-          "syntax": {
-            "method": ["coalesce", "value", "fallback"],
-            "result": "value"
-          },
-          "value": ["coalesce", ["image", ["concat", ["get", "icon"], "_15"]], ["image", "marker_15"] ]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["coalesce", "value", "fallback"],
+              "output-type": "value"
+            }
+          ]
         },
+        "example": ["coalesce", ["image", ["concat", ["get", "icon"], "_15"]], ["image", "marker_15"]],
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -3035,13 +3057,15 @@
       },
       "step": {
         "doc": "Produces discrete, stepped results by evaluating a piecewise-constant function defined by pairs of input and output values (\"stops\"). The `input` may be any numeric expression (e.g., `[\"get\", \"population\"]`). Stop inputs must be numeric literals in strictly ascending order.\n\nReturns the output value of the stop just less than the input, or the first output if the input is less than the first stop.\n\n - [Create and style clusters](https://maplibre.org/maplibre-gl-js/docs/examples/cluster/)",
-        "example": {
-          "syntax": {
-            "method": ["step", "input1", "output1", "input2", "output2", "..."],
-            "result": "number"
-          },
-          "value": [ "step", ["get", "point_count"], 20, 100, 30, 750, 40]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["step", "input1", "output1", "input2", "output2", "..."],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["step", ["get", "point_count"], 20, 100, 30, 750, 40],
         "group": "Ramps, scales, curves",
         "sdk-support": {
           "basic functionality": {
@@ -3053,13 +3077,15 @@
       },
       "interpolate": {
         "doc": "Produces continuous, smooth results by interpolating between pairs of input and output values (\"stops\"). The `input` may be any numeric expression (e.g., `[\"get\", \"population\"]`). Stop inputs must be numeric literals in strictly ascending order. The output type must be `number`, `array<number>`, or `color`.\n\nInterpolation types:\n\n- `[\"linear\"]`, or an expression returning one of those types: Interpolates linearly between the pair of stops just less than and just greater than the input.\n\n- `[\"exponential\", base]`: Interpolates exponentially between the stops just less than and just greater than the input. `base` controls the rate at which the output increases: higher values make the output increase more towards the high end of the range. With values close to 1 the output increases linearly.\n\n- `[\"cubic-bezier\", x1, y1, x2, y2]`: Interpolates using the cubic bezier curve defined by the given control points.\n\n - [Animate map camera around a point](https://maplibre.org/maplibre-gl-js/docs/examples/animate-camera-around-point/)\n\n - [Change building color based on zoom level](https://maplibre.org/maplibre-gl-js/docs/examples/change-building-color-based-on-zoom-level/)\n\n - [Create a heatmap layer](https://maplibre.org/maplibre-gl-js/docs/examples/heatmap-layer/)\n\n - [Visualize population density](https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/)",
-        "example": {
-          "syntax": {
-            "method": ["[\"linear\"] | [\"exponential\", base] | [\"cubic-bezier\", x1, y1, x2, y2]", "input1", "output1", "input2", "output2", "..."],
-            "result": "number | array<number> | color"
-          },
-          "value": ["interpolate", ["linear"], ["zoom"], 15, 0, 15.05, ["get", "height"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["[\"linear\"] | [\"exponential\", base] | [\"cubic-bezier\", x1, y1, x2, y2]", "input1", "output1", "input2", "output2", "..."],
+              "output-type": "number | array<number> | color"
+            }
+          ]
         },
+        "example": ["interpolate", ["linear"], ["zoom"], 15, 0, 15.05, ["get", "height"]],
         "group": "Ramps, scales, curves",
         "sdk-support": {
           "basic functionality": {
@@ -3071,13 +3097,15 @@
       },
       "interpolate-hcl": {
         "doc": "Produces continuous, smooth results by interpolating between pairs of input and output values (\"stops\"). Works like `interpolate`, but the output type must be `color`, and the interpolation is performed in the Hue-Chroma-Luminance color space.",
-        "example": {
-          "syntax": {
-            "method": ["[\"linear\"] | [\"exponential\", base] | [\"cubic-bezier\", x1, y1, x2, y2]", "input1", "output1", "input2", "output2", "..."],
-            "result": "color"
-          },
-          "value": ["interpolate-hcl", ["linear"], ["zoom"], 15, "#f00", 15.05, "#00f"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["[\"linear\"] | [\"exponential\", base] | [\"cubic-bezier\", x1, y1, x2, y2]", "input1", "output1", "input2", "output2", "..."],
+              "output-type": "color"
+            }
+          ]
         },
+        "example": ["interpolate-hcl", ["linear"], ["zoom"], 15, "#f00", 15.05, "#00f"],
         "group": "Ramps, scales, curves",
         "sdk-support": {
           "basic functionality": {
@@ -3089,13 +3117,15 @@
       },
       "interpolate-lab": {
         "doc": "Produces continuous, smooth results by interpolating between pairs of input and output values (\"stops\"). Works like `interpolate`, but the output type must be `color`, and the interpolation is performed in the CIELAB color space.",
-        "example": {
-          "syntax": {
-            "method": ["[\"linear\"] | [\"exponential\", base] | [\"cubic-bezier\", x1, y1, x2, y2]", "input1", "output1", "input2", "output2", "..."],
-            "result": "color"
-          },
-          "value": ["interpolate-lab", ["linear"], ["zoom"], 15, "#f00", 15.05, "#00f"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["[\"linear\"] | [\"exponential\", base] | [\"cubic-bezier\", x1, y1, x2, y2]", "input1", "output1", "input2", "output2", "..."],
+              "output-type": "color"
+            }
+          ]
         },
+        "example": ["interpolate-lab", ["linear"], ["zoom"], 15, "#f00", 15.05, "#00f"],
         "group": "Ramps, scales, curves",
         "sdk-support": {
           "basic functionality": {
@@ -3107,13 +3137,15 @@
       },
       "ln2": {
         "doc": "Returns mathematical constant ln(2).",
-        "example": {
-          "syntax": {
-            "method": [],
-            "result": "number"
-          },
-          "value": ["ln2"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": [],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["ln2"],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3125,13 +3157,15 @@
       },
       "pi": {
         "doc": "Returns the mathematical constant pi.",
-        "example": {
-          "syntax": {
-            "method": [],
-            "result": "number"
-          },
-          "value": ["pi"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": [],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["pi"],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3143,13 +3177,15 @@
       },
       "e": {
         "doc": "Returns the mathematical constant e.",
-        "example": {
-          "syntax": {
-            "method": [],
-            "result": "number"
-          },
-          "value": ["e"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": [],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["e"],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3161,13 +3197,15 @@
       },
       "typeof": {
         "doc": "Returns a string describing the type of the given value.",
-        "example": {
-          "syntax": {
-            "method": ["value"],
-            "result": "string"
-          },
-          "value": ["typeof", ["get", "name"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value"],
+              "output-type": "string"
+            }
+          ]
         },
+        "example": ["typeof", ["get", "name"]],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3179,13 +3217,15 @@
       },
       "string": {
         "doc": "Asserts that the input value is a string. If multiple values are provided, each one is evaluated in order until a string is obtained. If none of the inputs are strings, the expression is an error.",
-        "example": {
-          "syntax": {
-            "method": ["value", "fallback: value", "fallback: value", "..."],
-            "result": "string"
-          },
-          "value": ["string", ["get", "name"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "fallback: value", "fallback: value", "..."],
+              "output-type": "string"
+            }
+          ]
         },
+        "example": ["string", ["get", "name"]],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3197,13 +3237,15 @@
       },
       "number": {
         "doc": "Asserts that the input value is a number. If multiple values are provided, each one is evaluated in order until a number is obtained. If none of the inputs are numbers, the expression is an error.",
-        "example": {
-          "syntax": {
-            "method": ["value", "fallback: value", "fallback: value", "..."],
-            "result": "number"
-          },
-          "value": ["number", ["get", "population"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "fallback: value", "fallback: value", "..."],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["number", ["get", "population"]],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3215,13 +3257,15 @@
       },
       "boolean": {
         "doc": "Asserts that the input value is a boolean. If multiple values are provided, each one is evaluated in order until a boolean is obtained. If none of the inputs are booleans, the expression is an error.\n\n - [Create a hover effect](https://maplibre.org/maplibre-gl-js/docs/examples/hover-styles/)",
-        "example": {
-          "syntax": {
-            "method": ["value", "fallback: value", "fallback: value", "..."],
-            "result": "boolean"
-          },
-          "value": ["boolean", ["feature-state", "hover"], false]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "fallback: value", "fallback: value", "..."],
+              "output-type": "boolean"
+            }
+          ]
         },
+        "example": ["boolean", ["feature-state", "hover"], false],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3233,13 +3277,15 @@
       },
       "object": {
         "doc": "Asserts that the input value is an object. If multiple values are provided, each one is evaluated in order until an object is obtained. If none of the inputs are objects, the expression is an error.",
-        "example": {
-          "syntax": {
-            "method": ["value", "fallback: value", "fallback: value", "..."],
-            "result": "object"
-          },
-          "value": ["object", ["get", "some-property"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "fallback: value", "fallback: value", "..."],
+              "output-type": "object"
+            }
+          ]
         },
+        "example": ["object", ["get", "some-property"]],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3251,13 +3297,15 @@
       },
       "collator": {
         "doc": "Returns a `collator` for use in locale-dependent comparison operations. The `case-sensitive` and `diacritic-sensitive` options default to `false`. The `locale` argument specifies the IETF language tag of the locale to use. If none is provided, the default locale is used. If the requested locale is not available, the `collator` will use a system-defined fallback locale. Use `resolved-locale` to test the results of locale fallback behavior.",
-        "example": {
-          "syntax": {
-            "method": ["collator", "{ \"case-sensitive\": boolean, \"diacritic-sensitive\": boolean, \"locale\": string }"],
-            "result": "collator"
-          },
-          "value": ["collator", {"case-sensitive": true, "diacritic-sensitive": true, "locale": "fr"}]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["collator", "{ \"case-sensitive\": boolean, \"diacritic-sensitive\": boolean, \"locale\": string }"],
+              "output-type": "collator"
+            }
+          ]
         },
+        "example": ["collator", {"case-sensitive": true, "diacritic-sensitive": true, "locale": "fr"}],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3269,13 +3317,15 @@
       },
       "format": {
         "doc": "Returns a `formatted` string for displaying mixed-format text in the `text-field` property. The input may contain a string literal or expression, including an [`'image'`](#image) expression. Strings may be followed by a style override object that supports the following properties:\n\n- `\"text-font\"`: Overrides the font stack specified by the root layout property.\n\n- `\"text-color\"`: Overrides the color specified by the root paint property.\n\n- `\"font-scale\"`: Applies a scaling factor on `text-size` as specified by the root layout property.\n\n- `\"vertical-align\"`: Aligns vertically text section or image in relation to the row it belongs to. Possible values are: \n\t- `\"bottom\"` *default*: align the bottom of this section with the bottom of other sections.\n<img alt=\"Visual representation of bottom alignment\" src=\"https://github.com/user-attachments/assets/0474a2fd-a4b2-417c-9187-7a13a28695bc\"/>\n\t- `\"center\"`: align the center of this section with the center of other sections.\n<img alt=\"Visual representation of center alignment\" src=\"https://github.com/user-attachments/assets/92237455-be6d-4c5d-b8f6-8127effc1950\"/>\n\t- `\"top\"`: align the top of this section with the top of other sections.\n<img alt=\"Visual representation of top alignment\" src=\"https://github.com/user-attachments/assets/45dccb28-d977-4abb-a006-4ea9792b7c53\"/>\n\t- Refer to [the design proposal](https://github.com/maplibre/maplibre-style-spec/issues/832) for more details.\n\n - [Change the case of labels](https://maplibre.org/maplibre-gl-js/docs/examples/change-case-of-labels/)\n\n - [Display and style rich text labels](https://maplibre.org/maplibre-gl-js/docs/examples/display-and-style-rich-text-labels/)",
-        "example": {
-          "syntax": {
-            "method": ["value", "{ \"text-font\": string, \"text-color\": color, \"font-scale\": number, \"vertical-align\": \"bottom\" | \"center\" | \"top\" }", "..."],
-            "result": "formatted"
-          },
-          "value": ["format", ["upcase", ["get", "FacilityName"]], {"font-scale": 0.8}, "\n\n", {}, ["downcase", ["get", "Comments"]], {"font-scale": 0.6, "vertical-align": "center"}]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "{ \"text-font\": string, \"text-color\": color, \"font-scale\": number, \"vertical-align\": \"bottom\" | \"center\" | \"top\" }", "..."],
+              "output-type": "formatted"
+            }
+          ]
         },
+        "example": ["format", ["upcase", ["get", "FacilityName"]], {"font-scale": 0.8}, "\n\n", {}, ["downcase", ["get", "Comments"]], {"font-scale": 0.6, "vertical-align": "center"}],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3312,13 +3362,15 @@
       },
       "image": {
         "doc": "Returns an `image` type for use in `icon-image`, `*-pattern` entries and as a section in the `format` expression. If set, the `image` argument will check that the requested image exists in the style and will return either the resolved image name or `null`, depending on whether or not the image is currently in the style. This validation process is synchronous and requires the image to have been added to the style before requesting it in the `image` argument.\n\n - [Use a fallback image](https://maplibre.org/maplibre-gl-js/docs/examples/fallback-image/)",
-        "example": {
-          "syntax": {
-            "method": ["value"],
-            "result": "image"
-          },
-          "value": ["image", "marker_15"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value"],
+              "output-type": "image"
+            }
+          ]
         },
+        "example": ["image", "marker_15"],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3331,13 +3383,15 @@
       "global-state": {
         "doc": "Retrieves a property value from global state that can be set with platform-specific APIs. Defaults can be provided using the [`state`](https://maplibre.org/maplibre-style-spec/root/#state) root property. Returns `null` if no value nor default value is set for the retrieved property.",
         "group": "Lookup",
-        "example": {
-          "syntax": {
-            "method": ["string"],
-            "result": "value"
-          },
-          "value": ["global-state", "someProperty"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["string"],
+              "output-type": "value"
+            }
+          ]
         },
+        "example": ["global-state", "someProperty"],
         "sdk-support": {
           "basic functionality": {
             "js": "https://github.com/maplibre/maplibre-gl-js/issues/4964",
@@ -3348,13 +3402,15 @@
       },
       "number-format": {
         "doc": "Converts the input number into a string representation using the providing formatting rules. If set, the `locale` argument specifies the locale to use, as a BCP 47 language tag. If set, the `currency` argument specifies an ISO 4217 code to use for currency-style formatting. If set, the `min-fraction-digits` and `max-fraction-digits` arguments specify the minimum and maximum number of fractional digits to include.\n\n - [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js/docs/examples/cluster-html/)",
-        "example": {
-          "syntax": {
-            "method": ["number", "{ \"locale\": string, \"currency\": string, \"min-fraction-digits\": number, \"max-fraction-digits\": number }"],
-            "result": "string"
-          },
-          "value": ["number-format", ["get", "mag"], {"min-fraction-digits": 1, "max-fraction-digits": 1}]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number", "{ \"locale\": string, \"currency\": string, \"min-fraction-digits\": number, \"max-fraction-digits\": number }"],
+              "output-type": "string"
+            }
+          ]
         },
+        "example": ["number-format", ["get", "mag"], {"min-fraction-digits": 1, "max-fraction-digits": 1}],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3366,13 +3422,15 @@
       },
       "to-string": {
         "doc": "Converts the input value to a string. If the input is `null`, the result is `\"\"`. If the input is a boolean, the result is `\"true\"` or `\"false\"`. If the input is a number, it is converted to a string as specified by the [\"NumberToString\" algorithm](https://tc39.github.io/ecma262/#sec-tostring-applied-to-the-number-type) of the ECMAScript Language Specification. If the input is a color, it is converted to a string of the form `\"rgba(r,g,b,a)\"`, where `r`, `g`, and `b` are numerals ranging from 0 to 255, and `a` ranges from 0 to 1. Otherwise, the input is converted to a string in the format specified by the [`JSON.stringify`](https://tc39.github.io/ecma262/#sec-json.stringify) function of the ECMAScript Language Specification.\n\n - [Create a time slider](https://maplibre.org/maplibre-gl-js/docs/examples/timeline-animation/)",
-        "example": {
-          "syntax": {
-            "method": ["value"],
-            "result": "string"
-          },
-          "value": ["to-string", ["get", "mag"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value"],
+              "output-type": "string"
+            }
+          ]
         },
+        "example": ["to-string", ["get", "mag"]],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3384,13 +3442,15 @@
       },
       "to-number": {
         "doc": "Converts the input value to a number, if possible. If the input is `null` or `false`, the result is 0. If the input is `true`, the result is 1. If the input is a string, it is converted to a number as specified by the [\"ToNumber Applied to the String Type\" algorithm](https://tc39.github.io/ecma262/#sec-tonumber-applied-to-the-string-type) of the ECMAScript Language Specification. If multiple values are provided, each one is evaluated in order until the first successful conversion is obtained. If none of the inputs can be converted, the expression is an error.",
-        "example": {
-          "syntax": {
-            "method": ["value", "fallback: value", "fallback: value", "..."],
-            "result": "number"
-          },
-          "value": ["to-number", "someProperty"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "fallback: value", "fallback: value", "..."],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["to-number", "someProperty"],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3402,13 +3462,15 @@
       },
       "to-boolean": {
         "doc": "Converts the input value to a boolean. The result is `false` when then input is an empty string, 0, `false`, `null`, or `NaN`; otherwise it is `true`.",
-        "example": {
-          "syntax": {
-            "method": ["value"],
-            "result": "boolean"
-          },
-          "value": ["to-boolean", "someProperty"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value"],
+              "output-type": "boolean"
+            }
+          ]
         },
+        "example": ["to-boolean", "someProperty"],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3420,13 +3482,15 @@
       },
       "to-rgba": {
         "doc": "Returns a four-element array containing the input color's red, green, blue, and alpha components, in that order.",
-        "example": {
-          "syntax": {
-            "method": ["color"],
-            "result": "array"
-          },
-          "value": ["to-rgba", "#ff0000"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["color"],
+              "output-type": "array"
+            }
+          ]
         },
+        "example": ["to-rgba", "#ff0000"],
         "group": "Color",
         "sdk-support": {
           "basic functionality": {
@@ -3438,13 +3502,15 @@
       },
       "to-color": {
         "doc": "Converts the input value to a color. If multiple values are provided, each one is evaluated in order until the first successful conversion is obtained. If none of the inputs can be converted, the expression is an error.\n\n - [Visualize population density](https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/)",
-        "example": {
-          "syntax": {
-            "method": ["value", "fallback: value", "fallback: value", "..."],
-            "result": "color"
-          },
-          "value": ["to-color", "#edf8e9"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "fallback: value", "fallback: value", "..."],
+              "output-type": "color"
+            }
+          ]
         },
+        "example": ["to-color", "#edf8e9"],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
@@ -3456,13 +3522,15 @@
       },
       "rgb": {
         "doc": "Creates a color value from red, green, and blue components, which must range between 0 and 255, and an alpha component of 1. If any component is out of range, the expression is an error.",
-        "example": {
-          "syntax": {
-            "method": ["number", "number", "number"],
-            "result": "color"
-          },
-          "value": ["rgb", 255, 0, 0]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number", "number", "number"],
+              "output-type": "color"
+            }
+          ]
         },
+        "example": ["rgb", 255, 0, 0],
         "group": "Color",
         "sdk-support": {
           "basic functionality": {
@@ -3474,13 +3542,15 @@
       },
       "rgba": {
         "doc": "Creates a color value from red, green, blue components, which must range between 0 and 255, and an alpha component which must range between 0 and 1. If any component is out of range, the expression is an error.",
-        "example": {
-          "syntax": {
-            "method": ["number", "number", "number", "number"],
-            "result": "color"
-          },
-          "value": ["rgba", 255, 0, 0, 1]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number", "number", "number", "number"],
+              "output-type": "color"
+            }
+          ]
         },
+        "example": ["rgba", 255, 0, 0, 1],
         "group": "Color",
         "sdk-support": {
           "basic functionality": {
@@ -3492,13 +3562,15 @@
       },
       "get": {
         "doc": "Retrieves a property value from the current feature's properties, or from another object if a second argument is provided. Returns null if the requested property is missing.\n\n - [Change the case of labels](https://maplibre.org/maplibre-gl-js/docs/examples/change-case-of-labels/)\n\n - [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js/docs/examples/cluster-html/)\n\n - [Extrude polygons for 3D indoor mapping](https://maplibre.org/maplibre-gl-js/docs/examples/3d-extrusion-floorplan/)",
-        "example": {
-          "syntax": {
-            "method": ["string"],
-            "result": "value"
-          },
-          "value": ["get", "someProperty"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["string"],
+              "output-type": "value"
+            }
+          ]
         },
+        "example": ["get", "someProperty"],
         "group": "Lookup",
         "sdk-support": {
           "basic functionality": {
@@ -3510,13 +3582,15 @@
       },
       "has": {
         "doc": "Tests for the presence of an property value in the current feature's properties, or from another object if a second argument is provided.\n\n - [Create and style clusters](https://maplibre.org/maplibre-gl-js/docs/examples/cluster/)",
-        "example": {
-          "syntax": {
-            "method": ["string"],
-            "result": "boolean"
-          },
-          "value": ["has", "someProperty"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["string"],
+              "output-type": "boolean"
+            }
+          ]
         },
+        "example": ["has", "someProperty"],
         "group": "Lookup",
         "sdk-support": {
           "basic functionality": {
@@ -3528,13 +3602,15 @@
       },
       "length": {
         "doc": "Gets the length of an array or string. In a string, a UTF-16 surrogate pair counts as a single position.",
-        "example": {
-          "syntax": {
-            "method": ["array"],
-            "result": "number"
-          },
-          "value": ["length", ["get", "myArray"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["array"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["length", ["get", "myArray"]],
         "group": "Lookup",
         "sdk-support": {
           "basic functionality": {
@@ -3546,13 +3622,15 @@
       },
       "properties": {
         "doc": "Gets the feature properties object.  Note that in some cases, it may be more efficient to use [\"get\", \"property_name\"] directly.",
-        "example": {
-          "syntax": {
-            "method": [],
-            "result": "value"
-          },
-          "value": ["properties"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": [],
+              "output-type": "value"
+            }
+          ]
         },
+        "example": ["properties"],
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {
@@ -3564,13 +3642,15 @@
       },
       "feature-state": {
         "doc": "Retrieves a property value from the current feature's state. Returns null if the requested property is not present on the feature's state. A feature's state is not part of the GeoJSON or vector tile data, and must be set programmatically on each feature. When `source.promoteId` is not provided, features are identified by their `id` attribute, which must be an integer or a string that can be cast to an integer. When `source.promoteId` is provided, features are identified by their `promoteId` property, which may be a number, string, or any primitive data type. Note that [\"feature-state\"] can only be used with paint properties that support data-driven styling.\n\n - [Create a hover effect](https://maplibre.org/maplibre-gl-js/docs/examples/hover-styles/)",
-        "example": {
-          "syntax": {
-            "method": ["string"],
-            "result": "value"
-          },
-          "value": ["feature-state", "hover"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["string"],
+              "output-type": "value"
+            }
+          ]
         },
+        "example": ["feature-state", "hover"],
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {
@@ -3582,13 +3662,15 @@
       },
       "geometry-type": {
         "doc": "Returns the feature's simple geometry type: `Point`, `LineString`, or `Polygon`. `MultiPoint`, `MultiLineString`, and `MultiPolygon` are returned as `Point`, `LineString`, and `Polygon`, respectively.",
-        "example": {
-          "syntax": {
-            "method": [],
-            "result": "string"
-          },
-          "value": ["==", ["geometry-type"], "Polygon"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": [],
+              "output-type": "string"
+            }
+          ]
         },
+        "example": ["==", ["geometry-type"], "Polygon"],
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {
@@ -3600,13 +3682,15 @@
       },
       "id": {
         "doc": "Gets the feature's id, if it has one.",
-        "example": {
-          "syntax": {
-            "method": [],
-            "result": "value"
-          },
-          "value": ["id"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": [],
+              "output-type": "value"
+            }
+          ]
         },
+        "example": ["id"],
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {
@@ -3618,13 +3702,15 @@
       },
       "zoom": {
         "doc": "Gets the current zoom level.  Note that in style layout and paint properties, [\"zoom\"] may only appear as the input to a top-level \"step\" or \"interpolate\" expression.",
-        "example": {
-          "syntax": {
-            "method": [],
-            "result": "number"
-          },
-          "value": ["interpolate",["linear"],["zoom"],15,0,15.05,["get","height"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": [],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["interpolate", ["linear"], ["zoom"], 15, 0, 15.05, ["get", "height"]],
         "group": "Zoom",
         "sdk-support": {
           "basic functionality": {
@@ -3636,13 +3722,15 @@
       },
       "heatmap-density": {
         "doc": "Gets the kernel density estimation of a pixel in a heatmap layer, which is a relative measure of how many data points are crowded around a particular pixel. Can only be used in the `heatmap-color` property.",
-        "example": {
-          "syntax": {
-            "method": [],
-            "result": "number"
-          },
-          "value": ["heatmap-density"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": [],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["heatmap-density"],
         "group": "Heatmap",
         "sdk-support": {
           "basic functionality": {
@@ -3654,13 +3742,15 @@
       },
       "line-progress": {
         "doc": "Gets the progress along a gradient line. Can only be used in the `line-gradient` property.",
-        "example": {
-          "syntax": {
-            "method": ["number"],
-            "result": "number"
-          },
-          "value": ["line-progress", 0.5]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["line-progress", 0.5],
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {
@@ -3672,13 +3762,15 @@
       },
       "accumulated": {
         "doc": "Gets the value of a cluster property accumulated so far. Can only be used in the `clusterProperties` option of a clustered GeoJSON source.",
-        "example": {
-          "syntax": {
-            "method": ["string"],
-            "result": "value"
-          },
-          "value": ["accumulated", "sum"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["string"],
+              "output-type": "value"
+            }
+          ]
         },
+        "example": ["accumulated", "sum"],
         "group": "Feature data",
         "sdk-support": {
           "basic functionality": {
@@ -3690,13 +3782,15 @@
       },
       "+": {
         "doc": "Returns the sum of the inputs.",
-        "example": {
-          "syntax": {
-            "method": ["number", "number", "..."],
-            "result": "number"
-          },
-          "value": ["+", 2, 3]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number", "number", "..."],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["+", 2, 3],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3708,13 +3802,15 @@
       },
       "*": {
         "doc": "Returns the product of the inputs.",
-        "example": {
-          "syntax": {
-            "method": ["number", "number", "..."],
-            "result": "number"
-          },
-          "value": ["*", 2, 3]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number", "number", "..."],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["*", 2, 3],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3726,13 +3822,15 @@
       },
       "-": {
         "doc": "For two inputs, returns the result of subtracting the second input from the first. For a single input, returns the result of subtracting it from 0.",
-        "example": {
-          "syntax": {
-            "method": ["number", "number?"],
-            "result": "number"
-          },
-          "value": ["-", 10]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number", "number?"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["-", 10],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3744,13 +3842,15 @@
       },
       "/": {
         "doc": "Returns the result of floating point division of the first input by the second.\n\n - [Visualize population density](https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/)",
-        "example": {
-          "syntax": {
-            "method": ["number", "number"],
-            "result": "number"
-          },
-          "value": ["/", ["get", "population"], ["get", "sq-km"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number", "number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["/", ["get", "population"], ["get", "sq-km"]],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3762,13 +3862,15 @@
       },
       "%": {
         "doc": "Returns the remainder after integer division of the first input by the second.",
-        "example": {
-          "syntax": {
-            "method": ["number", "number"],
-            "result": "number"
-          },
-          "value": ["%", 10, 3]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number", "number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["%", 10, 3],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3780,13 +3882,15 @@
       },
       "^": {
         "doc": "Returns the result of raising the first input to the power specified by the second.",
-        "example": {
-          "syntax": {
-            "method": ["number", "number"],
-            "result": "number"
-          },
-          "value": ["^", 2, 3]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number", "number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["^", 2, 3],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3798,13 +3902,15 @@
       },
       "sqrt": {
         "doc": "Returns the square root of the input.",
-        "example": {
-          "syntax": {
-            "method": ["number"],
-            "result": "number"
-          },
-          "value": ["sqrt", 9]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["sqrt", 9],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3816,13 +3922,15 @@
       },
       "log10": {
         "doc": "Returns the base-ten logarithm of the input.",
-        "example": {
-          "syntax": {
-            "method": ["number"],
-            "result": "number"
-          },
-          "value": ["log10", 8]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["log10", 8],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3834,13 +3942,15 @@
       },
       "ln": {
         "doc": "Returns the natural logarithm of the input.",
-        "example": {
-          "syntax": {
-            "method": ["number"],
-            "result": "number"
-          },
-          "value": ["ln", 8]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["ln", 8],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3852,13 +3962,15 @@
       },
       "log2": {
         "doc": "Returns the base-two logarithm of the input.",
-        "example": {
-          "syntax": {
-            "method": ["number"],
-            "result": "number"
-          },
-          "value": ["log2", 8]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["log2", 8],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3870,13 +3982,15 @@
       },
       "sin": {
         "doc": "Returns the sine of the input.",
-        "example": {
-          "syntax": {
-            "method": ["number"],
-            "result": "number"
-          },
-          "value": ["sin", 1]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["sin", 1],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3888,13 +4002,15 @@
       },
       "cos": {
         "doc": "Returns the cosine of the input.",
-        "example": {
-          "syntax": {
-            "method": ["number"],
-            "result": "number"
-          },
-          "value": ["cos", 1]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["cos", 1],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3906,13 +4022,15 @@
       },
       "tan": {
         "doc": "Returns the tangent of the input.",
-        "example": {
-          "syntax": {
-            "method": ["number"],
-            "result": "number"
-          },
-          "value": ["tan", 1]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["tan", 1],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3924,13 +4042,15 @@
       },
       "asin": {
         "doc": "Returns the arcsine of the input.",
-        "example": {
-          "syntax": {
-            "method": ["number"],
-            "result": "number"
-          },
-          "value": ["asin", 1]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["asin", 1],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3942,13 +4062,15 @@
       },
       "acos": {
         "doc": "Returns the arccosine of the input.",
-        "example": {
-          "syntax": {
-            "method": ["number"],
-            "result": "number"
-          },
-          "value": ["acos", 1]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["acos", 1],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3960,13 +4082,15 @@
       },
       "atan": {
         "doc": "Returns the arctangent of the input.",
-        "example": {
-          "syntax": {
-            "method": ["number"],
-            "result": "number"
-          },
-          "value": ["atan", 1]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["atan", 1],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3978,13 +4102,15 @@
       },
       "min": {
         "doc": "Returns the minimum value of the inputs.",
-        "example": {
-          "syntax": {
-            "method": ["number", "number", "..."],
-            "result": "number"
-          },
-          "value": ["min", 1, 2]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number", "number", "..."],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["min", 1, 2],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -3996,13 +4122,15 @@
       },
       "max": {
         "doc": "Returns the maximum value of the inputs.",
-        "example": {
-          "syntax": {
-            "method": ["number", "number", "..."],
-            "result": "number"
-          },
-          "value": ["max", 1, 2]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number", "number", "..."],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["max", 1, 2],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -4014,13 +4142,15 @@
       },
       "round": {
         "doc": "Rounds the input to the nearest integer. Halfway values are rounded away from zero. For example, `[\"round\", -1.5]` evaluates to -2.",
-        "example": {
-          "syntax": {
-            "method": ["number"],
-            "result": "number"
-          },
-          "value": ["round", 1.5]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["round", 1.5],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -4032,13 +4162,15 @@
       },
       "abs": {
         "doc": "Returns the absolute value of the input.",
-        "example": {
-          "syntax": {
-            "method": ["number"],
-            "result": "number"
-          },
-          "value": ["abs", -1.5]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["abs", -1.5],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -4050,13 +4182,15 @@
       },
       "ceil": {
         "doc": "Returns the smallest integer that is greater than or equal to the input.",
-        "example": {
-          "syntax": {
-            "method": ["number"],
-            "result": "number"
-          },
-          "value": ["ceil", 1.5]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["ceil", 1.5],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -4068,13 +4202,15 @@
       },
       "floor": {
         "doc": "Returns the largest integer that is less than or equal to the input.",
-        "example": {
-          "syntax": {
-            "method": ["number"],
-            "result": "number"
-          },
-          "value": ["floor", 1.5]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["number"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["floor", 1.5],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -4086,13 +4222,15 @@
       },
       "distance": {
         "doc": "Returns the shortest distance in meters between the evaluated feature and the input geometry. The input value can be a valid GeoJSON of type `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, `Feature`, or `FeatureCollection`. Distance values returned may vary in precision due to loss in precision from encoding geometries, particularly below zoom level 13.",
-        "example": {
-          "syntax": {
-            "method": ["GeoJSON geometry"],
-            "result": "number"
-          },
-          "value": ["distance", { "type": "Point", "coordinates": [0, 0]}]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["GeoJSON geometry"],
+              "output-type": "number"
+            }
+          ]
         },
+        "example": ["distance", {"type": "Point", "coordinates": [0, 0]}],
         "group": "Math",
         "sdk-support": {
           "basic functionality": {
@@ -4104,13 +4242,15 @@
       },
       "==": {
         "doc": "Returns `true` if the input values are equal, `false` otherwise. The comparison is strictly typed: values of different runtime types are always considered unequal. Cases where the types are known to be different at parse time are considered invalid and will produce a parse error. Accepts an optional `collator` argument to control locale-dependent string comparisons.\n\n - [Add multiple geometries from one GeoJSON source](https://maplibre.org/maplibre-gl-js/docs/examples/multiple-geometries/)\n\n - [Create a time slider](https://maplibre.org/maplibre-gl-js/docs/examples/timeline-animation/)\n\n - [Display buildings in 3D](https://maplibre.org/maplibre-gl-js/docs/examples/3d-buildings/)\n\n - [Filter symbols by toggling a list](https://maplibre.org/maplibre-gl-js/docs/examples/filter-markers/)",
-        "example": {
-          "syntax": {
-            "method": ["value", "value", "collator?"],
-            "result": "boolean"
-          },
-          "value": ["==", "$type", "Polygon"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "value", "collator?"],
+              "output-type": "boolean"
+            }
+          ]
         },
+        "example": ["==", "$type", "Polygon"],
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -4127,13 +4267,15 @@
       },
       "!=": {
         "doc": "Returns `true` if the input values are not equal, `false` otherwise. The comparison is strictly typed: values of different runtime types are always considered unequal. Cases where the types are known to be different at parse time are considered invalid and will produce a parse error. Accepts an optional `collator` argument to control locale-dependent string comparisons.\n\n - [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js/docs/examples/cluster-html/)",
-        "example": {
-          "syntax": {
-            "method": ["value", "value", "collator?"],
-            "result": "boolean"
-          },
-          "value": ["!=", "cluster", true]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "value", "collator?"],
+              "output-type": "boolean"
+            }
+          ]
         },
+        "example": ["!=", "cluster", true],
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -4150,13 +4292,15 @@
       },
       ">": {
         "doc": "Returns `true` if the first input is strictly greater than the second, `false` otherwise. The arguments are required to be either both strings or both numbers; if during evaluation they are not, expression evaluation produces an error. Cases where this constraint is known not to hold at parse time are considered in valid and will produce a parse error. Accepts an optional `collator` argument to control locale-dependent string comparisons.",
-        "example": {
-            "syntax": {
-              "method": ["value", "value", "collator?"],
-              "result": "boolean"
-            },
-            "value": [">", ["get", "mag"], 2]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "value", "collator?"],
+              "output-type": "boolean"
+            }
+          ]
         },
+        "example": [">", ["get", "mag"], 2],
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -4173,13 +4317,15 @@
       },
       "<": {
         "doc": "Returns `true` if the first input is strictly less than the second, `false` otherwise. The arguments are required to be either both strings or both numbers; if during evaluation they are not, expression evaluation produces an error. Cases where this constraint is known not to hold at parse time are considered in valid and will produce a parse error. Accepts an optional `collator` argument to control locale-dependent string comparisons.\n\n - [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js/docs/examples/cluster-html/)",
-        "example": {
-          "syntax": {
-            "method": ["value", "value", "collator?"],
-            "result": "boolean"
-          },
-          "value": ["<", ["get", "mag"], 2]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "value", "collator?"],
+              "output-type": "boolean"
+            }
+          ]
         },
+        "example": ["<", ["get", "mag"], 2],
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -4196,13 +4342,15 @@
       },
       ">=": {
         "doc": "Returns `true` if the first input is greater than or equal to the second, `false` otherwise. The arguments are required to be either both strings or both numbers; if during evaluation they are not, expression evaluation produces an error. Cases where this constraint is known not to hold at parse time are considered in valid and will produce a parse error. Accepts an optional `collator` argument to control locale-dependent string comparisons.\n\n - [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js/docs/examples/cluster-html/)",
-        "example": {
-          "syntax": {
-            "method": ["value", "value", "collator?"],
-            "result": "boolean"
-          },
-          "value": [">=", ["get", "mag"], 6]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "value", "collator?"],
+              "output-type": "boolean"
+            }
+          ]
         },
+        "example": [">=", ["get", "mag"], 6],
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -4219,13 +4367,15 @@
       },
       "<=": {
         "doc": "Returns `true` if the first input is less than or equal to the second, `false` otherwise. The arguments are required to be either both strings or both numbers; if during evaluation they are not, expression evaluation produces an error. Cases where this constraint is known not to hold at parse time are considered in valid and will produce a parse error. Accepts an optional `collator` argument to control locale-dependent string comparisons.",
-        "example": {
-            "syntax": {
-              "method": ["value", "value", "collator?"],
-              "result": "boolean"
-            },
-            "value": ["<=", ["get", "mag"], 6]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "value", "collator?"],
+              "output-type": "boolean"
+            }
+          ]
         },
+        "example": ["<=", ["get", "mag"], 6],
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -4242,13 +4392,15 @@
       },
       "all": {
         "doc": "Returns `true` if all the inputs are `true`, `false` otherwise. The inputs are evaluated in order, and evaluation is short-circuiting: once an input expression evaluates to `false`, the result is `false` and no further input expressions are evaluated.\n\n - [Display HTML clusters with custom properties](https://maplibre.org/maplibre-gl-js/docs/examples/cluster-html/)",
-        "example": {
-          "syntax": {
-            "method": ["boolean", "boolean", "..."],
-            "result": "boolean"
-          },
-          "value": ["all", [">=", ["get", "mag"], 4], ["<", ["get", "mag"], 5]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["boolean", "boolean", "..."],
+              "output-type": "boolean"
+            }
+          ]
         },
+        "example": ["all", [">=", ["get", "mag"], 4], ["<", ["get", "mag"], 5]],
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -4260,13 +4412,15 @@
       },
       "any": {
         "doc": "Returns `true` if any of the inputs are `true`, `false` otherwise. The inputs are evaluated in order, and evaluation is short-circuiting: once an input expression evaluates to `true`, the result is `true` and no further input expressions are evaluated.",
-        "example": {
-          "syntax": {
-            "method": ["boolean", "boolean", "..."],
-            "result": "boolean"
-          },
-          "value": ["any", [">=", ["get", "mag"], 4], ["<", ["get", "mag"], 5]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["boolean", "boolean", "..."],
+              "output-type": "boolean"
+            }
+          ]
         },
+        "example": ["any", [">=", ["get", "mag"], 4], ["<", ["get", "mag"], 5]],
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -4278,13 +4432,15 @@
       },
       "!": {
         "doc": "Logical negation. Returns `true` if the input is `false`, and `false` if the input is `true`.\n\n - [Create and style clusters](https://maplibre.org/maplibre-gl-js/docs/examples/cluster/)",
-        "example": {
-          "syntax": {
-            "method": ["value", "value", "collator?"],
-            "result": "boolean"
-          },
-          "value": ["!", ["has", "point_count"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["value", "value", "collator?"],
+              "output-type": "boolean"
+            }
+          ]
         },
+        "example": ["!", ["has", "point_count"]],
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -4296,13 +4452,15 @@
       },
       "within": {
         "doc": "Returns `true` if the evaluated feature is fully contained inside a boundary of the input geometry, `false` otherwise. The input value can be a valid GeoJSON of type `Polygon`, `MultiPolygon`, `Feature`, or `FeatureCollection`. Supported features for evaluation:\n\n- `Point`: Returns `false` if a point is on the boundary or falls outside the boundary.\n\n- `LineString`: Returns `false` if any part of a line falls outside the boundary, the line intersects the boundary, or a line's endpoint is on the boundary.",
-        "example": {
-          "syntax": {
-            "method": ["GeoJSON geometry"],
-            "result": "boolean"
-          },
-          "value": ["within", {"type": "Polygon","coordinates": [[[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]]]}]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["GeoJSON geometry"],
+              "output-type": "boolean"
+            }
+          ]
         },
+        "example": ["within", {"type": "Polygon", "coordinates": [[[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]]]}],
         "group": "Decision",
         "sdk-support": {
           "basic functionality": {
@@ -4314,13 +4472,15 @@
       },
       "is-supported-script": {
         "doc": "Returns `true` if the input string is expected to render legibly. Returns `false` if the input string contains sections that cannot be rendered without potential loss of meaning (e.g. Indic scripts that require complex text shaping, or right-to-left scripts if the `mapbox-gl-rtl-text` plugin is not in use in MapLibre GL JS).",
-        "example": {
-          "syntax": {
-            "method": ["string"],
-            "result": "boolean"
-          },
-          "value": ["is-supported-script", "दिल्ली"]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["string"],
+              "output-type": "boolean"
+            }
+          ]
         },
+        "example": ["is-supported-script", "दिल्ली"],
         "group": "String",
         "sdk-support": {
           "basic functionality": {
@@ -4332,13 +4492,15 @@
       },
       "upcase": {
         "doc": "Returns the input string converted to uppercase. Follows the Unicode Default Case Conversion algorithm and the locale-insensitive case mappings in the Unicode Character Database.\n\n - [Change the case of labels](https://maplibre.org/maplibre-gl-js/docs/examples/change-case-of-labels/)",
-        "example": {
-          "syntax": {
-            "method": ["string"],
-            "result": "string"
-          },
-          "value": ["upcase", ["get", "name"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["string"],
+              "output-type": "string"
+            }
+          ]
         },
+        "example": ["upcase", ["get", "name"]],
         "group": "String",
         "sdk-support": {
           "basic functionality": {
@@ -4350,13 +4512,15 @@
       },
       "downcase": {
         "doc": "Returns the input string converted to lowercase. Follows the Unicode Default Case Conversion algorithm and the locale-insensitive case mappings in the Unicode Character Database.\n\n - [Change the case of labels](https://maplibre.org/maplibre-gl-js/docs/examples/change-case-of-labels/)",
-        "example": {
-          "syntax": {
-            "method": ["string"],
-            "result": "string"
-          },
-          "value": ["downcase", ["get", "name"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["string"],
+              "output-type": "string"
+            }
+          ]
         },
+        "example": ["downcase", ["get", "name"]],
         "group": "String",
         "sdk-support": {
           "basic functionality": {
@@ -4368,13 +4532,15 @@
       },
       "concat": {
         "doc": "Returns a `string` consisting of the concatenation of the inputs. Each input is converted to a string as if by `to-string`.\n\n - [Add a generated icon to the map](https://maplibre.org/maplibre-gl-js/docs/examples/add-image-missing-generated/)\n\n - [Create a time slider](https://maplibre.org/maplibre-gl-js/docs/examples/timeline-animation/)\n\n - [Use a fallback image](https://maplibre.org/maplibre-gl-js/docs/examples/fallback-image/)\n\n - [Variable label placement](https://maplibre.org/maplibre-gl-js/docs/examples/variable-label-placement/)",
-        "example": {
-          "syntax": {
-            "method": ["string", "string", "..."],
-            "result": "string"
-          },
-          "value": ["concat", "square-rgb-", ["get", "color"]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["string", "string", "..."],
+              "output-type": "string"
+            }
+          ]
         },
+        "example": ["concat", "square-rgb-", ["get", "color"]],
         "group": "String",
         "sdk-support": {
           "basic functionality": {
@@ -4386,16 +4552,18 @@
       },
       "resolved-locale": {
         "doc": "Returns the IETF language tag of the locale being used by the provided `collator`. This can be used to determine the default system locale, or to determine if a requested locale was successfully loaded.",
-        "example": {
-          "syntax": {
-            "method": ["collator"],
-            "result": "string"
-          },
-          "value": ["resolved-locale", [
-            "collator",
-            {"case-sensitive": true, "diacritic-sensitive": false, "locale": "de"}
-          ]]
+        "syntax": {
+          "variants": [
+            {
+              "parameters": ["collator"],
+              "output-type": "string"
+            }
+          ]
         },
+        "example": ["resolved-locale", [
+          "collator",
+          {"case-sensitive": true, "diacritic-sensitive": false, "locale": "de"}
+        ]],
         "group": "String",
         "sdk-support": {
           "basic functionality": {


### PR DESCRIPTION
Closes #1102
Closes #724

This changes the expression syntax documented on the Expressions page to follow the patterns proposed in #1102.
Some incorrectly documented syntaxes were fixed in the process.

`match` before:
<img width="725" alt="image" src="https://github.com/user-attachments/assets/b8243858-fc1e-415b-852a-3f4bc8e69333" />
`match` after:
<img width="725" alt="image" src="https://github.com/user-attachments/assets/d3311003-697f-480a-864a-9f4d57166ba1" />

`in` before:
<img width="725" alt="image" src="https://github.com/user-attachments/assets/c9093e9b-14a4-4ebb-90f9-d64d432793e2" />
`in` after:
<img width="725" alt="image" src="https://github.com/user-attachments/assets/92fa8730-435e-4b96-b957-10902fbb0e7d" />


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
