### PR TITLE
add missing global-state expression typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Add missing `global-state` expression typing ([#1130](https://github.com/maplibre/maplibre-style-spec/pull/1130))
 - _...Add new stuff here..._
 
 ## 23.2.3

--- a/build/generate-style-spec.ts
+++ b/build/generate-style-spec.ts
@@ -265,6 +265,8 @@ export type ExpressionSpecification =
     | ['zoom'] // number
     // Heatmap
     | ['heatmap-density'] // number
+    // Global state
+    | ['global-state', string] // unknown
 
 export type ExpressionFilterSpecification = boolean | ExpressionSpecification
 


### PR DESCRIPTION
Added missing `global-state` Expression typing...

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
