### PR TITLE
Fix JSON syntax in sprite.md

### DIFF
--- a/docs/sprite.md
+++ b/docs/sprite.md
@@ -27,18 +27,18 @@ You can also supply an array of `{ id: ..., url: ... }` pairs to load multiple s
 
 ```json
 "sprite": [
-  {
-    id: 'roadsigns',
-    url: 'https://example.com/myroadsigns'
-  },
-  {
-    id: 'shops',
-    url: 'https://example2.com/someurl'
-  },
-  {
-    id: 'default',
-    url: 'https://example2.com/anotherurl'
-  }
+    {
+        "id": "roadsigns",
+        "url": "https://example.com/myroadsigns"
+    },
+    {
+        "id": "shops",
+        "url": "https://example2.com/someurl"
+    },
+    {
+        "id": "default",
+        "url": "https://example2.com/anotherurl"
+    }
 ]
 ```
 


### PR DESCRIPTION
Currently it is marked as JSON but due to being JavaScript the hightlighter highlights it weirdly. This aligns it with the rest of the JSON on the page.

![Invalid formatting with https:// marked as a comment](https://github.com/user-attachments/assets/e50d4a59-c7af-4422-9c78-e23bdd391a0d)