### PR TITLE
Group vitest dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 20
     versioning-strategy: increase
+    groups:
+      vitest:
+        patterns:
+          - "*vitest*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Launch Checklist

See:
- https://github.com/maplibre/maplibre-gl-js/pull/6006
- https://github.com/maplibre/maplibre-gl-js/pull/6007

Group vitest dependencies update as was done in maplibre-gl-js to avoid installation failure of these packages.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
