### PR TITLE
Improve typings in expression integration test file

### DIFF
--- a/test/integration/expression/expression.test.ts
+++ b/test/integration/expression/expression.test.ts
@@ -181,8 +181,9 @@ function getCompilationSuccessResult(expression: StylePropertyExpression): Compi
 
 function evaluateExpression(inputs: FixtureInput[], expression: StylePropertyExpression): EvaluationOutput[] {
     const type = getStylePropertyExpressionType(expression);
+    const outputs: EvaluationOutput[] = [];
 
-    return inputs.map((input) => {
+    for (const input of inputs) {
         const {availableImages, canonicalID} = input[0];
         const {featureState, geometry, id, properties} = input[1];
 
@@ -212,15 +213,16 @@ function evaluateExpression(inputs: FixtureInput[], expression: StylePropertyExp
             if (type.kind === 'color') {
                 value = [value.r, value.g, value.b, value.a];
             }
-            return value;
+            outputs.push(value);
         } catch (error) {
-            return {
+            outputs.push({
                 error: error.name === 'ExpressionEvaluationError' ?
                     error.toJSON() :
                     error.message,
-            };
+            });
         }
-    });
+    }
+    return outputs;
 }
 
 function getStylePropertyExpressionType(expression: StylePropertyExpression) {

--- a/test/integration/expression/expression.test.ts
+++ b/test/integration/expression/expression.test.ts
@@ -7,31 +7,71 @@ import {
     convertFunction,
     toString,
     ICanonicalTileID,
-    StylePropertyExpression
+    StylePropertyExpression,
+    StylePropertySpecification,
+    ZoomConstantExpression,
+    StyleExpression,
+    GlobalProperties,
+    Feature,
+    ZoomDependentExpression
 } from '../../../src/index';
 import {ExpressionParsingError} from '../../../src/expression/parsing_error';
-import {Result} from '../../../src/util/result';
 import {getGeometry} from '../../lib/geometry';
 import {deepEqual, stripPrecision} from '../../lib/json-diff';
 import {describe, expect, test} from 'vitest';
 
-const DECIMAL_SIGNIFICANT_FIGURES =  6;
+const DECIMAL_SIGNIFICANT_FIGURES = 6;
+
+type Mutable<T> = {
+    -readonly [K in keyof T]: T[K];
+};
 
 type ExpressionFixture = {
-    propertySpec: any;
+    propertySpec?: Partial<StylePropertySpecification>;
     expression: any[];
-    inputs:any[];
-    expected: {
-        compiled?: {
-            result?: any;
-            isFeatureConstant?: any;
-            isZoomConstant?: any;
-            type?: any;
+    inputs?: FixtureInput[];
+    expected?: FixtureResult;
+};
+
+type FixtureInput = [
+    Partial<GlobalProperties> & {
+        availableImages?: string[];
+        canonicalID?: {
+            z: number;
+            x: number;
+            y: number;
         };
-        outputs? : any;
-        serialized?: any;
-    };
-}
+    },
+    {
+        properties?: Record<string, any>;
+        featureState?: Record<string, any>;
+        id?: any;
+        geometry?: GeoJSON.Point | GeoJSON.MultiPoint | GeoJSON.LineString | GeoJSON.MultiLineString | GeoJSON.Polygon | GeoJSON.MultiPolygon;
+    },
+];
+
+type FixtureResult = FixtureErrorResult | FixtureSuccessResult;
+type FixtureErrorResult = {
+    compiled: CompilationErrorResult;
+};
+type FixtureSuccessResult = {
+    compiled: CompilationSuccessResult;
+    outputs: any[];
+};
+
+type CompilationErrorResult = {
+    result: 'error';
+    errors: {
+        key: string;
+        error: string;
+    }[];
+};
+type CompilationSuccessResult = {
+    result: 'success';
+    isFeatureConstant: boolean;
+    isZoomConstant: boolean;
+    type: string;
+};
 
 const expressionTestFileNames = globSync('**/test.json', {cwd: __dirname});
 describe('expression', () => {
@@ -39,148 +79,148 @@ describe('expression', () => {
     for (const expressionTestFileName of expressionTestFileNames) {
         test(expressionTestFileName, () => {
 
-            const fixture = JSON.parse(fs.readFileSync(path.join(__dirname, expressionTestFileName), 'utf8'));
+            const fixturePath = path.join(__dirname, expressionTestFileName);
+            const fixture: ExpressionFixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
 
-            const result = evaluateFixture(fixture);
+            const spec = getCompletePropertySpec(fixture.propertySpec);
+            const result = evaluateFixture(fixture, spec);
 
             if (process.env.UPDATE) {
-                fixture.expected = {
-                    compiled: result.compiled,
-                    outputs: stripPrecision(result.outputs, DECIMAL_SIGNIFICANT_FIGURES),
-                };
+                fixture.expected = isFixtureErrorResult(result) ?
+                    result :
+                    {
+                        compiled: result.compiled,
+                        outputs: stripPrecision(result.outputs, DECIMAL_SIGNIFICANT_FIGURES),
+                    };
+                if (fixture.propertySpec) {
+                    fixture.propertySpec = spec;
+                }
 
-                delete fixture.metadata;
-
-                const fname = path.join(__dirname, expressionTestFileName);
-                fs.writeFileSync(fname, JSON.stringify(fixture, null, 2));
+                fs.writeFileSync(fixturePath, JSON.stringify(fixture, null, 2));
                 return;
             }
 
-            const expected = fixture.expected;
+            const expected = fixture.expected as FixtureResult;
+
             const compileOk = deepEqual(result.compiled, expected.compiled, DECIMAL_SIGNIFICANT_FIGURES);
-            
-            const evalOk = compileOk && deepEqual(result.outputs, expected.outputs, DECIMAL_SIGNIFICANT_FIGURES);
-            
             try {
                 expect(compileOk).toBeTruthy();
             } catch {
                 throw new Error(`Compilation Failed:\nExpected ${JSON.stringify(expected.compiled)}\nResult   ${JSON.stringify(result.compiled)}`);
             }
-            
+
+            const resultOutputs = (result as any).outputs;
+            const expectedOutputs = (expected as any).outputs;
+            const evalOk = compileOk && deepEqual(resultOutputs, expectedOutputs, DECIMAL_SIGNIFICANT_FIGURES);
             try {
                 expect(evalOk).toBeTruthy();
             } catch {
-                throw new Error(`Evaluation Failed:\nExpected ${JSON.stringify(expected.outputs)}\nResult   ${JSON.stringify(result.outputs)}`);
+                throw new Error(`Evaluation Failed:\nExpected ${JSON.stringify(expectedOutputs)}\nResult   ${JSON.stringify(resultOutputs)}`);
             }
 
         });
     }
 });
 
-function evaluateFixture(fixture: ExpressionFixture) {
-    const spec = fixture.propertySpec || {};
-
+function getCompletePropertySpec(propertySpec: ExpressionFixture['propertySpec']) {
+    const spec = propertySpec === undefined ? {} : {...propertySpec};
     if (!spec['property-type']) {
         spec['property-type'] = 'data-driven';
     }
-
     if (!spec['expression']) {
         spec['expression'] = {
             'interpolated': true,
-            'parameters': ['zoom', 'feature']
+            'parameters': ['zoom', 'feature'],
         };
     }
+    return spec as StylePropertySpecification;
+}
 
+function evaluateFixture(fixture: ExpressionFixture, spec: StylePropertySpecification): FixtureResult {
     const expression = isFunction(fixture.expression) ?
         createPropertyExpression(convertFunction(fixture.expression, spec), spec) :
         createPropertyExpression(fixture.expression, spec);
 
-    const result: { compiled: any; outputs?: any } = {
-        compiled: getCompilationResult(expression)
-    };
-
-    if (result.compiled.result !== 'error') {
-        result.outputs = evaluateExpression(fixture, expression);
-    }
-
-    return result;
-}
-
-function getCompilationResult(expression: Result<StylePropertyExpression, ExpressionParsingError[]>) {
-    const compilationResult = {} as any;
     if (expression.result === 'error') {
-        compilationResult.result = 'error';
-        compilationResult.errors = expression.value.map((err) => ({
-            key: err.key,
-            error: err.message
-        }));
-        return compilationResult;
+        return {
+            compiled: getCompilationErrorResult(expression.value),
+        };
     }
-
-    const expressionValue = expression.value;
-    const type = (expressionValue as any)._styleExpression.expression.type; // :scream:
-
-    compilationResult.result = 'success';
-    compilationResult.isFeatureConstant = expressionValue.kind === 'constant' || expressionValue.kind === 'camera';
-    compilationResult.isZoomConstant = expressionValue.kind === 'constant' || expressionValue.kind === 'source';
-    compilationResult.type = toString(type);
-
-    return compilationResult;
+    return {
+        compiled: getCompilationSuccessResult(expression.value),
+        outputs: fixture.inputs === undefined ? [] : evaluateExpression(fixture.inputs, expression.value),
+    };
 }
 
-function evaluateExpression(fixture: ExpressionFixture, expression: Result<StylePropertyExpression, ExpressionParsingError[]>) {
+function getCompilationErrorResult(parsingErrors: ExpressionParsingError[]): CompilationErrorResult {
+    return {
+        result: 'error',
+        errors: parsingErrors.map((err) => ({
+            key: err.key,
+            error: err.message,
+        })),
+    };
+}
 
-    let availableImages: any[];
-    let canonical: ICanonicalTileID | null;
+function getCompilationSuccessResult(expression: StylePropertyExpression): CompilationSuccessResult {
+    const kind = expression.kind;
+    const type = getStylePropertyExpressionType(expression);
+    return {
+        result: 'success',
+        isFeatureConstant: kind === 'constant' || kind ==='camera',
+        isZoomConstant: kind === 'constant' || kind === 'source',
+        type: toString(type),
+    };
+}
 
-    const evaluationResult: any[] = [];
+function evaluateExpression(inputs: FixtureInput[], expression: StylePropertyExpression) {
+    const type = getStylePropertyExpressionType(expression);
 
-    const expressionValue = expression.value;
-    const type = (expressionValue as any)._styleExpression.expression.type; // :scream:
+    return inputs.map((input) => {
+        const {availableImages, canonicalID} = input[0];
+        const {featureState, geometry, id, properties} = input[1];
 
-    for (const input of fixture.inputs || []) {
-        try {
-            const feature: {
-                properties: any;
-                id?: any;
-                type?: any;
-            } = {properties: input[1].properties || {}};
-            const featureState = input[1].featureState ?? {};
-            availableImages = input[0].availableImages || [];
-            if ('canonicalID' in input[0]) {
-                const id = input[0].canonicalID;
-                canonical = {z: id.z, x: id.x, y: id.y} as any;
+        const canonical = (canonicalID ?? null) as ICanonicalTileID | null;
+        const feature: Partial<Mutable<Feature>> = {
+            properties: properties ?? {},
+        };
+        if (id !== undefined) {
+            feature.id = id;
+        }
+        if (geometry !== undefined) {
+            if (canonical !== null) {
+                getGeometry(feature, geometry, canonical);
             } else {
-                canonical = null;
+                feature.type = geometry.type;
             }
+        }
 
-            if ('id' in input[1]) {
-                feature.id = input[1].id;
-            }
-            if ('geometry' in input[1]) {
-                if (canonical !== null) {
-                    getGeometry(feature, input[1].geometry, canonical);
-                } else {
-                    feature.type = input[1].geometry.type;
-                }
-            }
-
-            let value = expressionValue.evaluateWithoutErrorHandling(input[0], feature, featureState, canonical, availableImages);
-            
+        try {
+            let value = (expression as ZoomConstantExpression<any> | ZoomDependentExpression<any>).evaluateWithoutErrorHandling(
+                input[0] as GlobalProperties,
+                feature as Feature,
+                featureState ?? {},
+                canonical as ICanonicalTileID,
+                availableImages ?? [],
+            );
             if (type.kind === 'color') {
                 value = [value.r, value.g, value.b, value.a];
             }
-            evaluationResult.push(value);
+            return value;
         } catch (error) {
-            if (error.name === 'ExpressionEvaluationError') {
-                evaluationResult.push({error: error.toJSON()});
-            } else {
-                evaluationResult.push({error: error.message});
-            }
+            return {
+                error: error.name === 'ExpressionEvaluationError' ?
+                    error.toJSON() :
+                    error.message,
+            };
         }
-    }
+    });
+}
 
-    if (fixture.inputs) {
-        return evaluationResult;
-    }
+function getStylePropertyExpressionType(expression: StylePropertyExpression) {
+    return ((expression as any)._styleExpression as StyleExpression).expression.type;
+}
+
+function isFixtureErrorResult(fixtureResult: FixtureResult): fixtureResult is FixtureErrorResult {
+    return fixtureResult.compiled.result === 'error';
 }

--- a/test/integration/expression/expression.test.ts
+++ b/test/integration/expression/expression.test.ts
@@ -56,7 +56,7 @@ type FixtureErrorResult = {
 };
 type FixtureSuccessResult = {
     compiled: CompilationSuccessResult;
-    outputs: any[];
+    outputs: EvaluationOutput[];
 };
 
 type CompilationErrorResult = {
@@ -72,6 +72,12 @@ type CompilationSuccessResult = {
     isZoomConstant: boolean;
     type: string;
 };
+
+type EvaluationOutput = EvaluationErrorOutput | EvaluationSuccessOutput;
+type EvaluationErrorOutput = {
+    error: string;
+};
+type EvaluationSuccessOutput = any;
 
 const expressionTestFileNames = globSync('**/test.json', {cwd: __dirname});
 describe('expression', () => {
@@ -173,7 +179,7 @@ function getCompilationSuccessResult(expression: StylePropertyExpression): Compi
     };
 }
 
-function evaluateExpression(inputs: FixtureInput[], expression: StylePropertyExpression) {
+function evaluateExpression(inputs: FixtureInput[], expression: StylePropertyExpression): EvaluationOutput[] {
     const type = getStylePropertyExpressionType(expression);
 
     return inputs.map((input) => {


### PR DESCRIPTION
Improves typings in `expression.test.ts` along with some minor refactoring (mostly to aid with type inference).
These changes were originally a part of https://github.com/maplibre/maplibre-style-spec/pull/1158 but were moved to this separate PR as suggested in https://github.com/maplibre/maplibre-style-spec/pull/1158#issuecomment-2953737315.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
