### PR TITLE
Remove Flow type declaration workaround for Intl type

### DIFF
--- a/src/expression/definitions/number_format.ts
+++ b/src/expression/definitions/number_format.ts
@@ -5,25 +5,6 @@ import type {EvaluationContext} from '../evaluation_context';
 import type {ParsingContext} from '../parsing_context';
 import type {Type} from '../types';
 
-declare let Intl: {
-    NumberFormat: {
-        new (...args: any): Intl$NumberFormat;
-    };
-};
-
-declare class Intl$NumberFormat {
-    constructor(locales?: string | string[], options?: NumberFormatOptions);
-    format(a: number): string;
-    resolvedOptions(): any;
-}
-
-type NumberFormatOptions = {
-    style?: 'decimal' | 'currency' | 'percent';
-    currency?: null | string;
-    minimumFractionDigits?: null | string;
-    maximumFractionDigits?: null | string;
-};
-
 export class NumberFormat implements Expression {
     type: Type;
     number: Expression;

--- a/src/expression/types/collator.ts
+++ b/src/expression/types/collator.ts
@@ -1,31 +1,7 @@
-// Flow type declarations for Intl cribbed from
-// https://github.com/facebook/flow/issues/1270
-
-declare let Intl: {
-    Collator: {
-        new (...args: any): Intl$Collator;
-    };
-};
-
-declare class Intl$Collator {
-    constructor(locales?: string | string[], options?: CollatorOptions);
-    compare(a: string, b: string): number;
-    resolvedOptions(): any;
-}
-
-type CollatorOptions = {
-    localeMatcher?: 'lookup' | 'best fit';
-    usage?: 'sort' | 'search';
-    sensitivity?: 'base' | 'accent' | 'case' | 'variant';
-    ignorePunctuation?: boolean;
-    numeric?: boolean;
-    caseFirst?: 'upper' | 'lower' | 'false';
-};
-
 export class Collator {
     locale: string | null;
     sensitivity: 'base' | 'accent' | 'case' | 'variant';
-    collator: Intl$Collator;
+    collator: Intl.Collator;
 
     constructor(caseSensitive: boolean, diacriticSensitive: boolean, locale: string | null) {
         if (caseSensitive)


### PR DESCRIPTION
Removed obsolete type declarations/definitions for the Intl type which seem to have been left over from the Flow days.
These types are freely available in TS (`lib.ESNext` should contain these types).

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Briefly describe the changes in this PR.
