### PR TITLE
Fix migrate function to allow transition properties

### DIFF
--- a/src/migrate.test.ts
+++ b/src/migrate.test.ts
@@ -3,7 +3,7 @@ import * as spec from '.';
 import v8 from './reference/v8.json' with {type: 'json'};
 import {validateStyle} from './validate_style';
 import {describe, test, expect} from 'vitest';
-import type { StyleSpecification } from './types.g';
+import type {StyleSpecification} from './types.g';
 
 describe('migrate', () => {
     test('does not migrate from version 5', () => {

--- a/src/migrate.test.ts
+++ b/src/migrate.test.ts
@@ -3,6 +3,7 @@ import * as spec from '.';
 import v8 from './reference/v8.json' with {type: 'json'};
 import {validateStyle} from './validate_style';
 import {describe, test, expect} from 'vitest';
+import type { StyleSpecification } from './types.g';
 
 describe('migrate', () => {
     test('does not migrate from version 5', () => {
@@ -140,4 +141,25 @@ describe('migrate', () => {
         });
     });
 
+    test('migrates successfully when style contains transition properties', () => {
+        const style: StyleSpecification = {
+            version: 8,
+            sources: {},
+            layers: [{
+                id: 'layer-with-transition',
+                type: 'symbol',
+                source: 'vector-source',
+                paint: {
+                    'icon-color': 'hsl(100,0.3,.2)',
+                    'icon-opacity-transition': {duration: 0},
+                },
+            }],
+        };
+
+        expect(() => migrate(style)).not.toThrow();
+        expect(style.layers[0].paint).toEqual({
+            'icon-color': 'hsl(100,30%,20%)',
+            'icon-opacity-transition': {duration: 0},
+        });
+    });
 });

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -30,7 +30,7 @@ export function migrate(style: StyleSpecification): StyleSpecification {
     }
 
     eachProperty(style, {paint: true, layout: true}, ({value, reference, set}) => {
-        if (reference.type === 'color') {
+        if (reference?.type === 'color') {
             set(migrateColors(value));
         }
     });

--- a/src/migrate/expressions.ts
+++ b/src/migrate/expressions.ts
@@ -21,8 +21,8 @@ export function expressions(style: StyleSpecification) {
         }
     });
 
-    eachProperty(style, {paint: true, layout: true}, ({path, value, reference, set}) => {
-        if (isExpression(value)) return;
+    eachProperty(style, {paint: true, layout: true}, ({path, key, value, reference, set}) => {
+        if (isExpression(value) || key.endsWith('-transition') || reference === null) return;
         if (typeof value === 'object' && !Array.isArray(value)) {
             set(convertFunction(value, reference));
             converted.push(path.join('.'));

--- a/src/visit.ts
+++ b/src/visit.ts
@@ -8,15 +8,15 @@ import type {
     DataDrivenPropertyValueSpecification
 } from './types.g';
 
-function getPropertyReference(propertyName): StylePropertySpecification | null {
+function getPropertyReference(propertyName: string): StylePropertySpecification | null {
     for (let i = 0; i < Reference.layout.length; i++) {
         for (const key in Reference[Reference.layout[i]]) {
-            if (key === propertyName) return Reference[Reference.layout[i]][key] as any;
+            if (key === propertyName) return Reference[Reference.layout[i]][key];
         }
     }
     for (let i = 0; i < Reference.paint.length; i++) {
         for (const key in Reference[Reference.paint[i]]) {
-            if (key === propertyName) return Reference[Reference.paint[i]][key] as any;
+            if (key === propertyName) return Reference[Reference.paint[i]][key];
         }
     }
 
@@ -55,8 +55,8 @@ export function eachProperty(
     },
     callback: PropertyCallback
 ) {
-    function inner(layer, propertyType: 'paint' | 'layout') {
-        const properties = (layer[propertyType] as any);
+    function inner(layer: LayerSpecification, propertyType: 'paint' | 'layout') {
+        const properties = layer[propertyType];
         if (!properties) return;
         Object.keys(properties).forEach((key) => {
             callback({

--- a/src/visit.ts
+++ b/src/visit.ts
@@ -8,7 +8,7 @@ import type {
     DataDrivenPropertyValueSpecification
 } from './types.g';
 
-function getPropertyReference(propertyName): StylePropertySpecification {
+function getPropertyReference(propertyName): StylePropertySpecification | null {
     for (let i = 0; i < Reference.layout.length; i++) {
         for (const key in Reference[Reference.layout[i]]) {
             if (key === propertyName) return Reference[Reference.layout[i]][key] as any;
@@ -40,7 +40,7 @@ type PropertyCallback = (
         path: [string, 'paint' | 'layout', string]; // [layerid, paint/layout, property key],
         key: string;
         value: PropertyValueSpecification<unknown> | DataDrivenPropertyValueSpecification<unknown>;
-        reference: StylePropertySpecification;
+        reference: StylePropertySpecification | null;
         set: (
             a: PropertyValueSpecification<unknown> | DataDrivenPropertyValueSpecification<unknown>
         ) => void;


### PR DESCRIPTION
This PR prevents the migrate script from throwing when trying to migrate a style containing `*-transition` properties.

The migrate function currently errors because it assumes that each property in the style object is defined in v8.json under the exact same name, which transition properties are not.
This fix simply makes it so transition properties are not attempted to be transformed (see `expression.ts` line 25).

Resolves #35.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
