### PR TITLE
Fix arg order in array expression example

### DIFF
--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -2998,7 +2998,7 @@
             }
           ]
         },
-        "example": ["array", ["literal", ["a", "b", "c"]], "string", 3],
+        "example": ["array", "string", 3, ["literal", ["a", "b", "c"]]],
         "group": "Types",
         "sdk-support": {
           "basic functionality": {


### PR DESCRIPTION
This fixes the array expression example to have its arguments in the correct (valid) order.

Before:
<img width="633" alt="image" src="https://github.com/user-attachments/assets/cdd0a906-ad1c-45e3-9bc8-f55a16c35703" />

After:
<img width="626" alt="image" src="https://github.com/user-attachments/assets/c6f61671-f9c4-4b74-94fd-29f3a5ccdaff" />


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.