### PR TITLE
Fix arg arity error message in `index-of` and `slice` expressions

### DIFF
--- a/src/expression/definitions/index_of.ts
+++ b/src/expression/definitions/index_of.ts
@@ -31,7 +31,7 @@ export class IndexOf implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression {
         if (args.length <= 2 ||  args.length >= 5) {
-            return context.error(`Expected 3 or 4 arguments, but found ${args.length - 1} instead.`) as null;
+            return context.error(`Expected 2 or 3 arguments, but found ${args.length - 1} instead.`) as null;
         }
 
         const needle = context.parse(args[1], 1, ValueType);

--- a/src/expression/definitions/slice.ts
+++ b/src/expression/definitions/slice.ts
@@ -31,7 +31,7 @@ export class Slice implements Expression {
 
     static parse(args: ReadonlyArray<unknown>, context: ParsingContext): Expression {
         if (args.length <= 2 ||  args.length >= 5) {
-            return context.error(`Expected 3 or 4 arguments, but found ${args.length - 1} instead.`) as null;
+            return context.error(`Expected 2 or 3 arguments, but found ${args.length - 1} instead.`) as null;
         }
 
         const input = context.parse(args[1], 1, ValueType);

--- a/test/integration/expression/tests/index-of/missing-haystack/test.json
+++ b/test/integration/expression/tests/index-of/missing-haystack/test.json
@@ -9,7 +9,7 @@
       "errors": [
         {
           "key": "",
-          "error": "Expected 3 or 4 arguments, but found 1 instead."
+          "error": "Expected 2 or 3 arguments, but found 1 instead."
         }
       ]
     }

--- a/test/integration/expression/tests/index-of/missing-needle/test.json
+++ b/test/integration/expression/tests/index-of/missing-needle/test.json
@@ -8,7 +8,7 @@
       "errors": [
         {
           "key": "",
-          "error": "Expected 3 or 4 arguments, but found 0 instead."
+          "error": "Expected 2 or 3 arguments, but found 0 instead."
         }
       ]
     }

--- a/test/integration/expression/tests/index-of/unexpected-fourth-arg/test.json
+++ b/test/integration/expression/tests/index-of/unexpected-fourth-arg/test.json
@@ -12,7 +12,7 @@
       "errors": [
         {
           "key": "",
-          "error": "Expected 3 or 4 arguments, but found 4 instead."
+          "error": "Expected 2 or 3 arguments, but found 4 instead."
         }
       ]
     }

--- a/test/integration/expression/tests/slice/missing-input-arg/test.json
+++ b/test/integration/expression/tests/slice/missing-input-arg/test.json
@@ -8,7 +8,7 @@
       "errors": [
         {
           "key": "",
-          "error": "Expected 3 or 4 arguments, but found 0 instead."
+          "error": "Expected 2 or 3 arguments, but found 0 instead."
         }
       ]
     }

--- a/test/integration/expression/tests/slice/missing-start-index-arg/test.json
+++ b/test/integration/expression/tests/slice/missing-start-index-arg/test.json
@@ -9,7 +9,7 @@
       "errors": [
         {
           "key": "",
-          "error": "Expected 3 or 4 arguments, but found 1 instead."
+          "error": "Expected 2 or 3 arguments, but found 1 instead."
         }
       ]
     }

--- a/test/integration/expression/tests/slice/unexpected-fourth-arg/test.json
+++ b/test/integration/expression/tests/slice/unexpected-fourth-arg/test.json
@@ -12,7 +12,7 @@
       "errors": [
         {
           "key": "",
-          "error": "Expected 3 or 4 arguments, but found 4 instead."
+          "error": "Expected 2 or 3 arguments, but found 4 instead."
         }
       ]
     }


### PR DESCRIPTION
This fixes the expected number of args described in the error message given when passing an invalid number of args to `index-of` and `slice` expressions.

See the changed `*/unexpected-fourth-arg/test.json` files — The parser currently incorrectly returns "Expected 3 or 4 arguments, but found 4 instead.", which is clearly nonsensical; this PR changes the message to correctly say "Expected 2 or 3 arguments".

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.