### PR TITLE
Add JSDoc comments to types generated from v8.json

### DIFF
--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -1,6 +1,6 @@
 import v8 from '../src/reference/v8.json' with { type: 'json' };
 import fs from 'fs';
-import jsonStringify from 'json-stringify-pretty-compact';
+import {formatJSON} from './util';
 
 /**
  * This script generates markdown documentation from the JSON schema.
@@ -70,17 +70,6 @@ function topicElement(key: string, value: JsonObject): boolean {
         key !== 'sprite' &&
         key !== 'layers' &&
         key !== 'sources';
-}
-
-/**
- * @param obj - object to be formatted
- * @returns formatted JSON
- */
-function formatJSON(obj: any): string {
-    return jsonStringify(obj, {
-        indent: 4,
-        maxLength: 60
-    });
 }
 
 /**

--- a/build/util.ts
+++ b/build/util.ts
@@ -1,0 +1,14 @@
+import jsonStringify from 'json-stringify-pretty-compact';
+
+/**
+ * Formats a JSON value into a reasonably compact and readable JSON string.
+ * 
+ * @param obj - object to be formatted
+ * @returns formatted JSON
+ */
+export function formatJSON(obj: any) {
+    return jsonStringify(obj, {
+        indent: 4,
+        maxLength: 60
+    });
+}


### PR DESCRIPTION
Changed `generate-style-spec.ts` to include the `doc`, `default`, and `example` fields from v8.json as JSDoc annotations in the output type declarations file.

Before:
<img width="1534" height="284" alt="image" src="https://github.com/user-attachments/assets/61adc09c-018a-4954-86bf-ec2f0ef1aa9c" />

After:
<img width="775" height="134" alt="image" src="https://github.com/user-attachments/assets/2eead3e3-393c-434e-8d7c-a32051134e41" />

https://github.com/user-attachments/assets/a8df3039-d304-418a-b569-3acff636740c

Closes #1218.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
