### PR TITLE
Document global state implemented in Maplibre GL JS 5.6

### DIFF
--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -111,7 +111,7 @@
       },
       "sdk-support": {
         "basic functionality": {
-          "js": "https://github.com/maplibre/maplibre-gl-js/issues/4964",
+          "js": "5.6.0",
           "android": "https://github.com/maplibre/maplibre-native/issues/3302",
           "ios": "https://github.com/maplibre/maplibre-native/issues/3302"
         }


### PR DESCRIPTION
See https://github.com/maplibre/maplibre-gl-js/issues/4964, https://github.com/maplibre/maplibre-gl-js/pull/5613 and release https://github.com/maplibre/maplibre-gl-js/releases/tag/v5.6.0.

Currently the feature is marked as unimplemented, while it has been implemented since 5.6.0.

<img width="742" height="543" alt="image" src="https://github.com/user-attachments/assets/e1fe9f50-df4d-4c1a-b760-4a00e5a20f44" />

Thanks for all the work on this feature.

