### PR TITLE
Make sure example keys are surrounded by quotes

### DIFF
--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -79,7 +79,7 @@ function topicElement(key: string, value: JsonObject): boolean {
  * @returns the markdown string
  */
 function exampleToMarkdown(key: string, example: string | object | number): string {
-    return codeBlockMarkdown(`${key}: ${formatJSON(example)}`);
+    return codeBlockMarkdown(`"${key}": ${formatJSON(example)}`);
 }
 
 function codeBlockMarkdown(code: string, language = 'json'): string {


### PR DESCRIPTION
Makes it easier to copy.

Before

<img width="821" height="161" alt="image" src="https://github.com/user-attachments/assets/bc0ab08d-f009-425b-9bd2-6bb67e284bf1" />

After

<img width="738" height="125" alt="image" src="https://github.com/user-attachments/assets/88c44e28-e245-404d-9640-6708224d6f87" />
