### PR TITLE
Fix passing reference to `global-state` object when creating filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
+- Added `global-state` parameter to `featureFilter` function ([#1279](https://github.com/maplibre/maplibre-style-spec/pull/1279))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/feature_filter/feature_filter.test.ts
+++ b/src/feature_filter/feature_filter.test.ts
@@ -97,6 +97,12 @@ describe('filter', () => {
         expect(withinFilter.filter({zoom: 3}, featureInTile, canonical)).toBe(false);
     });
 
+    test('expression, global-state', () => {
+        const {filter} = featureFilter(['==', ['global-state', 'x'], ['get', 'x']], {x: 1});
+        expect(filter(undefined, {properties: {x: 1}} as any as Feature)).toBe(true);
+        expect(filter(undefined, {properties: {x: 2}} as any as Feature)).toBe(false);
+    });
+
     legacyFilterTests(featureFilter);
 
 });


### PR DESCRIPTION
This PR adds `global-state` parameter to `featureFilter` function. Without this fix filters based on `global-state` won't work. It should have been done as part of PR #1267.
 
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
