### PR TITLE
Update data-driven styling version for JS SDK

### DIFF
--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -6387,7 +6387,7 @@
           "ios": "2.0.0"
         },
         "data-driven styling": {
-          "js": "https://github.com/maplibre/maplibre-gl-js/issues/1235",
+          "js": "5.8.0",
           "ios": "https://github.com/maplibre/maplibre-native/issues/744",
           "android": "https://github.com/maplibre/maplibre-native/issues/744"
         }


### PR DESCRIPTION
This PR updates the spec to indicate that support for data-driven styling was added to line-dasharray in the JS SKD in [v5.8.0](https://github.com/maplibre/maplibre-gl-js/releases/tag/v5.8.0).

Related to #1100 
Related to https://github.com/maplibre/maplibre-gl-js/issues/1235

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] ~Include before/after visuals or gifs if this PR includes visual changes.~
 - [ ] ~Write tests for all new functionality.~
 - [x] Document any changes to public APIs.
 - [ ] ~Post benchmark scores.~
 - [ ] ~Add an entry to `CHANGELOG.md` under the `## main` section.~
