### PR TITLE
GL JS v5.6.0 supports `global-state`

### DIFF
--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -3822,7 +3822,7 @@
         "example": ["global-state", "someProperty"],
         "sdk-support": {
           "basic functionality": {
-            "js": "https://github.com/maplibre/maplibre-gl-js/issues/4964",
+            "js": "5.6.0",
             "android": "https://github.com/maplibre/maplibre-native/issues/3302",
             "ios": "https://github.com/maplibre/maplibre-native/issues/3302"
           }


### PR DESCRIPTION
maplibre/maplibre-gl-js#5613 added support for the `global-state` expression operator. This change went into v5.6.0. maplibre/maplibre-style-spec#1228 updated the compatibility table for the `state` property at the root. However, it didn’t touch the compatibility table for `global-state`, as seen in that PR’s screenshot. This PR updates the `global-state` compatibility table to match.