### PR TITLE
chore: remove a dead code path in build/generate-style-spec.ts

### DIFF
--- a/build/generate-style-spec.ts
+++ b/build/generate-style-spec.ts
@@ -67,20 +67,8 @@ function propertyType(property) {
                     return `Array<${elementType}>`;
                 }
             }
-            case 'light':
-                return 'LightSpecification';
-            case 'sky':
-                return 'SkySpecification';
             case 'sources':
                 return '{[_: string]: SourceSpecification}';
-            case 'projection:':
-                return 'ProjectionSpecification';
-            case 'state':
-                return 'StateSpecification';
-            case 'numberArray':
-                return 'NumberArraySpecification';
-            case 'colorArray':
-                return 'ColorArraySpecification';
             case '*':
                 return 'unknown';
             default:


### PR DESCRIPTION
This code is the same as what the `default` branch does