### PR TITLE
chore: fix inconsistent variadic variable naming

### DIFF
--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -2936,18 +2936,18 @@
         "syntax": {
           "overloads": [
             {
-              "parameters": ["var_1_name", "var_1_value", "...", "var_n_name", "var_n_value", "expression"],
+              "parameters": ["var_name_1", "var_value_1", "...", "var_name_n", "var_value_n", "expression"],
               "output-type": "any"
             }
           ],
           "parameters": [
             {
-              "name": "var_i_name",
+              "name": "var_name_i",
               "type": "string literal",
               "doc": "The name of the i-th variable."
             },
             {
-              "name": "var_i_value",
+              "name": "var_value_i",
               "type": "any",
               "doc": "The value of the i-th variable."
             },
@@ -3356,7 +3356,7 @@
         "syntax": {
           "overloads": [
             {
-              "parameters": ["input", "output_0", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
+              "parameters": ["input", "output_0", "stop_input_1", "stop_output_1", "...", "stop_input_n", "stop_output_n"],
               "output-type": "any"
             }
           ],
@@ -3372,12 +3372,12 @@
               "doc": "The result when the `input` is less than the first stop."
             },
             {
-              "name": "stop_i_input",
+              "name": "stop_input_i",
               "type": "number literal",
               "doc": "The value of the i-th stop against which the `input` is compared."
             },
             {
-              "name": "stop_i_output",
+              "name": "stop_output_i",
               "type": "any",
               "doc": "The result when the i-th stop is the last stop less than the `input`."
             }
@@ -3398,7 +3398,7 @@
         "syntax": {
           "overloads": [
             {
-              "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
+              "parameters": ["interpolation_type", "input", "stop_input_1", "stop_output_1", "...", "stop_input_n", "stop_output_n"],
               "output-type": ["number", "array<number>", "color", "array<color>", "projection"]
             }
           ],
@@ -3414,12 +3414,12 @@
               "doc": "Any numeric expression."
             },
             {
-              "name": "stop_i_input",
+              "name": "stop_input_i",
               "type": "number literal",
               "doc": "The value of the i-th stop against which the `input` is compared."
             },
             {
-              "name": "stop_i_output",
+              "name": "stop_output_i",
               "type": ["number", "array<number>", "color", "array<color>", "projection"],
               "doc": "The output value corresponding to the i-th stop."
             }
@@ -3440,7 +3440,7 @@
         "syntax": {
           "overloads": [
             {
-              "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
+              "parameters": ["interpolation_type", "input", "stop_input_1", "stop_output_1", "...", "stop_input_n", "stop_output_n"],
               "output-type": ["color", "array<color>"]
             }
           ],
@@ -3455,11 +3455,11 @@
               "type": "number"
             },
             {
-              "name": "stop_i_input",
+              "name": "stop_input_i",
               "type": "number literal"
             },
             {
-              "name": "stop_i_output",
+              "name": "stop_output_i",
               "type": ["color", "array<color>"]
             }
           ]
@@ -3479,7 +3479,7 @@
         "syntax": {
           "overloads": [
             {
-              "parameters": ["interpolation_type", "input", "stop_1_input", "stop_1_output", "...", "stop_n_input", "stop_n_output"],
+              "parameters": ["interpolation_type", "input", "stop_input_1", "stop_output_1", "...", "stop_input_n", "stop_output_n"],
               "output-type": ["color", "array<color>"]
             }
           ],
@@ -3494,11 +3494,11 @@
               "type": "number"
             },
             {
-              "name": "stop_i_input",
+              "name": "stop_input_i",
               "type": "number literal"
             },
             {
-              "name": "stop_i_output",
+              "name": "stop_output_i",
               "type": ["color", "array<color>"]
             }
           ]


### PR DESCRIPTION
Some of our variadic overloads are named with the _i" suffix and others are not named this way.
We should name them consistently.