### PR TITLE
Restore classic theme variant for Zensical migration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ extra_css:
   - assets/extra.css
 theme:
   name: 'material'
+  variant: classic
   favicon: https://maplibre.org/favicon.ico
   logo: assets/logo.svg
   features:


### PR DESCRIPTION
Zensical migration dropped the sidebar navigation and MapLibre branding when viewed in Safari. Adding variant: classic restores the Material for MkDocs look and feel. 

No console log errors in Safari.

Issue not reproduced on Chrome or Firefox.

I suspect this is an upstream issue with Zensical... investigating and will report back, in the meantime, any objection to reverting to the "classic" theme?

EDIT: I filed https://github.com/zensical/ui/issues/80

| Before | After |
|--------|-------|
| <img width="1224" height="894" alt="Screenshot 2026-03-04 at 2 17 38 PM" src="https://github.com/user-attachments/assets/5c44e9f9-43ad-447f-9cd9-23c8922eab95" />| <img width="1224" height="894" alt="Screenshot 2026-03-04 at 2 17 58 PM" src="https://github.com/user-attachments/assets/daefec42-0991-4831-a732-63c8310b24db" />| 

## Testing

Fix works locally 

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
