### PR TITLE
Fix `get` expression inside `join` expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix `get` expression inside `join` expression ([#1583](https://github.com/maplibre/maplibre-style-spec/pull/1583))
 - _...Add new stuff here..._
 
 ## 24.8.0

--- a/src/expression/compound_expression.ts
+++ b/src/expression/compound_expression.ts
@@ -516,7 +516,7 @@ CompoundExpression.register(expressions, {
     join: [
         StringType,
         [array(StringType), StringType],
-        (ctx, [arr, delim]) => (arr as any).value.join(delim.evaluate(ctx))
+        (ctx, [arr, delim]) => arr.evaluate(ctx).join(delim.evaluate(ctx))
     ],
     'resolved-locale': [
         StringType,

--- a/test/integration/expression/tests/join/property/test.json
+++ b/test/integration/expression/tests/join/property/test.json
@@ -1,0 +1,35 @@
+{
+  "expression": [
+    "join",
+    [
+      "get",
+      "haystack"
+    ],
+    "+"
+  ],
+  "inputs": [
+    [
+      {},
+      {
+        "properties": {
+          "haystack": [
+            "1",
+            "2",
+            "3"
+          ]
+        }
+      }
+    ]
+  ],
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": false,
+      "isZoomConstant": true,
+      "type": "string"
+    },
+    "outputs": [
+      "1+2+3"
+    ]
+  }
+}


### PR DESCRIPTION
Properly evaluate the input to a `join` expression. Manually pulling the literal value out of it is only appropriate for legacy style filter implementations because we don’t expect the inputs to those filters to contain complex data types.

Fixes maplibre/maplibre-gl-js#7337.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
