### PR TITLE
docs: Fix Text Fit Properties lists format

### DIFF
--- a/docs/sprite.md
+++ b/docs/sprite.md
@@ -105,22 +105,24 @@ The red highlighted part is where the stretch will occur over the Y axis and the
 #### Text Fit Properties
 
 The properties `textFitWidth` and `textFitHeight` alter how a sprite's content rectangle maps to its contents when scaling a sprite.  These properties are defined with the enum TextFit which may have the following values:
-* `stretchOrShrink` (or omitted)
-* `stretchOnly`
-* `proportional`
+
+- `stretchOrShrink` (or omitted)
+- `stretchOnly`
+- `proportional`
 
 The primary use cases of interest are:
+
 1. Both properties are undefined or stretchOrShrink
 
-   The content rectangle scales precisely to contain its contents.
+    The content rectangle scales precisely to contain its contents.
 
 2. textFitWidth = stretchOnly and textFitHeight = proportional
 
-   The content rectangle scales to precisely contain the height of its contents but the width will not shrink smaller than the aspect ratio of the original content rectangle. This is primarily useful for shields that shouldn't become too narrow if their contents are narrow (like the number "1").
+    The content rectangle scales to precisely contain the height of its contents but the width will not shrink smaller than the aspect ratio of the original content rectangle. This is primarily useful for shields that shouldn't become too narrow if their contents are narrow (like the number "1").
 
 3. textFitWidth = proportional and textFitHeight = stretchOnly
 
-   The content rectangle scales to precisely contain the width of its contents but the height will not shrink smaller than the aspect ratio of the original content rectangle. This may be useful scenarios like no. 2 except with vertically written scripts (using `"text-writing-mode": ["vertical"]`).
+    The content rectangle scales to precisely contain the width of its contents but the height will not shrink smaller than the aspect ratio of the original content rectangle. This may be useful scenarios like no. 2 except with vertically written scripts (using `"text-writing-mode": ["vertical"]`).
 
 ![image](https://github.com/DavidBuerer/maplibre-style-spec/assets/29717748/5fc7134e-28dc-4c3c-b89e-d89b50b8dbfa)
 


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.

---

Fix formatting of Text Fit Properties lists.
TextFit enum values are displayed as one-line text.
Use cases have all 1 in a numbered list.

Before:

https://maplibre.org/maplibre-style-spec/sprite/#text-fit-properties

<img width="715" height="508" alt="image" src="https://github.com/user-attachments/assets/e76ab23c-7705-4205-9bf8-9e880c5f8ec1" />

After:

<img width="720" height="647" alt="image" src="https://github.com/user-attachments/assets/4722f6fb-985d-4806-8b78-e58370fdabc8" />

