### PR TITLE
Mention uv as an option to serve docs locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ We use [Zensical](https://www.zensical.org/).
 
 For local development of the documentation, start Zensical. When you have Docker installed and running, you can use:
 
-```
+```bash
 npm run start-docs
 ```
 
 Alternatively, if you have [uv](https://docs.astral.sh/uv/) installed, you can use:
 
-```
+```bash
 uvx zensical serve --open
 ```
 
@@ -72,20 +72,20 @@ This repo contains scripts for migrating GL styles of any version to the latest 
 You can migrate a style like this:
 
 ```bash
-$ gl-style-migrate bright-v7.json > bright-v8.json
+gl-style-migrate bright-v7.json > bright-v8.json
 ```
 
 To migrate a file in place, you can use the `sponge` utility from the `moreutils` package:
 
 ```bash
-$ brew install moreutils
-$ gl-style-migrate bright.json | sponge bright.json
+brew install moreutils
+gl-style-migrate bright.json | sponge bright.json
 ```
 
 ### `gl-style-format`
 
 ```bash
-$ gl-style-format style.json
+gl-style-format style.json
 ```
 
 Will format the given style JSON to use standard indentation and sorted object keys.
@@ -93,7 +93,7 @@ Will format the given style JSON to use standard indentation and sorted object k
 ### `gl-style-validate`
 
 ```bash
-$ gl-style-validate style.json
+gl-style-validate style.json
 ```
 
 Will validate the given style JSON and print errors to stdout.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We aim to avoid breaking changes in the MapLibre style specification because it 
 The [documentation](https://maplibre.org/maplibre-style-spec) of the style specification also lives in this repository.
 We use [Zensical](https://www.zensical.org/).
 
-For local development of the documentation, start Zensical. When you have Docker installed and running, you can use:
+To work on the documentation locally you need to start Zensical. When you have Docker installed and running, you can use:
 
 ```bash
 npm run start-docs

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We aim to avoid breaking changes in the MapLibre style specification because it 
 The [documentation](https://maplibre.org/maplibre-style-spec) of the style specification also lives in this repository.
 We use [Zensical](https://www.zensical.org/).
 
-To work on the documentation locally you need to start Zensical. When you have Docker installed and running, you can use:
+To work on the documentation locally, you need to start Zensical. When you have Docker installed and running, you can use:
 
 ```bash
 npm run start-docs

--- a/README.md
+++ b/README.md
@@ -23,17 +23,23 @@ We aim to avoid breaking changes in the MapLibre style specification because it 
 The [documentation](https://maplibre.org/maplibre-style-spec) of the style specification also lives in this repository.
 We use [Zensical](https://www.zensical.org/).
 
-To work on the documentation locally, you need to have Docker installed and running.
-Start Zensical with
+For local development of the documentation, start Zensical. When you have Docker installed and running, you can use:
 
-```bash
+```
 npm run start-docs
+```
+
+Alternatively, if you have [uv](https://docs.astral.sh/uv/) installed, you can use:
+
+```
+uvx zensical serve --open
 ```
 
 Most of the documentation is generated (from e.g. `v8.json`).
 In another terminal, run:
 
 ```bash
+npm install
 WATCH=1 npm run generate-docs
 ```
 


### PR DESCRIPTION
I really like not running Docker if I can avoid it. Even on my Linux box, I don't use Docker but podman.

And uv is really nice. But! To each their own. I would like to just mention it as an option in the README.