### PR TITLE
fix: replace rw with node:fs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Replace rw with node:fs. Fix #1625 
 - _...Add new stuff here..._
 
 ## 24.8.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- Replace rw with node:fs. Fix #1625
+- Replace rw with node:fs. Fix #1625 ([#1635](https://github.com/maplibre/maplibre-style-spec/pull/1635)) (by [@birkskyum](https://github.com/birkskyum))
 - _...Add new stuff here..._
 
 ## 24.8.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- Replace rw with node:fs. Fix #1625 
+- Replace rw with node:fs. Fix #1625
 - _...Add new stuff here..._
 
 ## 24.8.3

--- a/bin/gl-style-validate.ts
+++ b/bin/gl-style-validate.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import minimist from 'minimist';
-import rw from 'rw';
+import {readFileSync} from 'node:fs';
 import {validateStyle as validate} from '../src/validate_style';
 
 const argv = minimist(process.argv.slice(2), {
@@ -18,7 +18,7 @@ if (argv.help || argv.h || (!argv._.length && process.stdin.isTTY)) {
     }
 
     argv._.forEach((file) => {
-        const errors = validate(rw.readFileSync(file, 'utf8'));
+        const errors = validate(readFileSync(file === '/dev/stdin' ? 0 : file, 'utf8'));
         if (errors.length) {
             if (argv.json) {
                 process.stdout.write(JSON.stringify(errors, null, 2));

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
         "quickselect": "^3.0.0",
-        "rw": "^1.3.3",
         "tinyqueue": "^3.0.0"
       },
       "bin": {
@@ -31,7 +30,7 @@
         "@types/node": "^25.6.0",
         "@typescript-eslint/eslint-plugin": "^8.59.1",
         "@typescript-eslint/parser": "^8.58.2",
-        "@typescript/native-preview": "*",
+        "@typescript/native-preview": "beta",
         "@vitest/coverage-v8": "4.1.5",
         "@vitest/eslint-plugin": "^1.6.16",
         "@vitest/ui": "4.1.5",
@@ -4055,11 +4054,6 @@
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
       }
-    },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "node_modules/semver": {
       "version": "7.7.4",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "json-stringify-pretty-compact": "^4.0.0",
     "minimist": "^1.2.8",
     "quickselect": "^3.0.0",
-    "rw": "^1.3.3",
     "tinyqueue": "^3.0.0"
   },
   "sideEffects": false,

--- a/test/build/style-spec.test.ts
+++ b/test/build/style-spec.test.ts
@@ -47,15 +47,19 @@ describe('@maplibre/maplibre-gl-style-spec npm package', () => {
     });
 });
 
-describe('CLI binaries (.mjs)', () => {
-    test.each(['gl-style-validate', 'gl-style-format', 'gl-style-migrate'])(
-        '%s.mjs starts without throwing',
-        (cli) => {
-            const result = spawnSync('node', [`dist/${cli}.mjs`, '--help'], {encoding: 'utf8'});
-            expect(result.status).toBe(0);
-            expect(result.stderr).toBe('');
-        }
-    );
+describe('CLI binaries', () => {
+    test.each([
+        ['gl-style-validate', 'mjs'],
+        ['gl-style-validate', 'cjs'],
+        ['gl-style-format', 'mjs'],
+        ['gl-style-format', 'cjs'],
+        ['gl-style-migrate', 'mjs'],
+        ['gl-style-migrate', 'cjs']
+    ])('%s.%s starts without throwing', (cli, ext) => {
+        const result = spawnSync('node', [`dist/${cli}.${ext}`, '--help'], {encoding: 'utf8'});
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe('');
+    });
 
     test('gl-style-validate accepts a file path', () => {
         const path = join(tmpdir(), 'maplibre-style-spec-valid.json');

--- a/test/build/style-spec.test.ts
+++ b/test/build/style-spec.test.ts
@@ -2,8 +2,12 @@ import {readdir} from 'fs/promises';
 import {latest} from '../../src/reference/latest';
 import {latest as latestInBundle} from '../../dist';
 import fs from 'fs';
+import {spawnSync} from 'node:child_process';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import {describe, test, expect} from 'vitest';
 const minBundle = fs.readFileSync('dist/index.mjs', 'utf8');
+const validStyle = JSON.stringify({version: 8, sources: {}, layers: []});
 
 describe('@maplibre/maplibre-gl-style-spec npm package', () => {
     test('files build', async () => {
@@ -40,5 +44,42 @@ describe('@maplibre/maplibre-gl-style-spec npm package', () => {
 
     test('"latest" entry point should be defined', async () => {
         expect(latestInBundle).toBeDefined();
+    });
+});
+
+describe('CLI binaries (.mjs)', () => {
+    test.each(['gl-style-validate', 'gl-style-format', 'gl-style-migrate'])(
+        '%s.mjs starts without throwing',
+        (cli) => {
+            const result = spawnSync('node', [`dist/${cli}.mjs`, '--help'], {encoding: 'utf8'});
+            expect(result.status).toBe(0);
+            expect(result.stderr).toBe('');
+        }
+    );
+
+    test('gl-style-validate accepts a file path', () => {
+        const path = join(tmpdir(), 'maplibre-style-spec-valid.json');
+        fs.writeFileSync(path, validStyle);
+        const result = spawnSync('node', ['dist/gl-style-validate.mjs', path], {encoding: 'utf8'});
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe('');
+    });
+
+    test('gl-style-validate accepts stdin', () => {
+        const result = spawnSync('node', ['dist/gl-style-validate.mjs'], {
+            encoding: 'utf8',
+            input: validStyle
+        });
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe('');
+    });
+
+    test('gl-style-validate exits 1 and reports errors for an invalid style', () => {
+        const result = spawnSync('node', ['dist/gl-style-validate.mjs'], {
+            encoding: 'utf8',
+            input: '{"version": 7, "sources": {}, "layers": "nope"}'
+        });
+        expect(result.status).toBe(1);
+        expect(result.stdout).toContain('version: expected one of [8]');
     });
 });


### PR DESCRIPTION
Closes #1625 
- #1625 

The ESM build of `gl-style-validate` threw on launch because rolldown bundled `rw` (a 9-year unmaintained CommonJS package) into `dist/gl-style-validate.mjs`. Its internal `require('fs')` calls became a `__require()` shim that throws in pure ESM context.

`rw`'s only feature this CLI used was treating `/dev/stdin` as a file path. Modern Node supports the same via `readFileSync(0, 'utf8')` (file descriptor 0 = stdin), so swap it for the built-in and drop the dependency.


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
