### PR TITLE
add missing imports and exports to index.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- _Added exports for DffCommand, DiffOperations, FeatureFilter, and VisibilityExpression_
+- Added missing exported types ([#1638](https://github.com/maplibre/maplibre-style-spec/pull/1638)) (by [@scottg521](https://github.com/scottg521))
+- _...Add new stuff here..._
 
 ## 24.8.4
 ### ✨ Features and improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- _...Add new stuff here..._
+- _Added exports for DffCommand, DiffOperations, FeatureFilter, and VisibilityExpression_
 
 ## 24.8.4
 ### ✨ Features and improvements

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ import {Padding} from './expression/types/padding';
 import {NumberArray} from './expression/types/number_array';
 import {ColorArray} from './expression/types/color_array';
 import {VariableAnchorOffsetCollection} from './expression/types/variable_anchor_offset_collection';
-import {Formatted, FormattedSection} from './expression/types/formatted';
+import {Formatted, FormattedSection, VerticalAlign} from './expression/types/formatted';
 import {createFunction, isFunction} from './function';
 import {convertFunction} from './function/convert';
 import {eachSource, eachLayer, eachProperty} from './visit';
@@ -42,6 +42,7 @@ import type {
     ILngLat,
     ILngLatLike
 } from './tiles_and_coordinates';
+import {Point2D} from './point2d';
 import {EvaluationContext} from './expression/evaluation_context';
 import {
     FormattedType,
@@ -51,7 +52,7 @@ import {
     ColorType,
     ProjectionDefinitionType
 } from './expression/types';
-
+import {Expression} from './expression/expression';
 import {expressions} from './expression/definitions';
 import {Interpolate} from './expression/definitions/interpolate';
 import {interpolateFactory, type InterpolationType} from './expression/definitions/interpolate';
@@ -231,7 +232,9 @@ export type {
     ILngLatLike,
     Type,
     InterpolationType,
-    FormattedSection
+    VerticalAlign,
+    Point2D,
+    Expression
 };
 
 export {
@@ -256,6 +259,7 @@ export {
     ZoomDependentExpression,
     FormatExpression,
     VisibilityExpression,
+    FormattedSection,
     latest,
     validateStyleMin,
     groupByLayout,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import v8Spec from './reference/v8.json' with {type: 'json'};
 const v8 = v8Spec as any;
 import latest from './reference/latest';
 import {derefLayers} from './deref';
-import {diff} from './diff';
+import {diff, type DiffCommand, type DiffOperations} from './diff';
 import {ValidationError} from './error/validation_error';
 import {ParsingError} from './error/parsing_error';
 import {
@@ -22,7 +22,7 @@ import {
     CompositeExpression,
     StylePropertyExpression
 } from './expression';
-import {featureFilter, isExpressionFilter} from './feature_filter';
+import {type FeatureFilter, featureFilter, isExpressionFilter} from './feature_filter';
 
 import {convertFilter} from './feature_filter/convert';
 import {Color} from './expression/types/color';
@@ -77,7 +77,7 @@ import {validate} from './validate/validate';
 import {migrate} from './migrate';
 import {classifyRings} from './util/classify_rings';
 import {ProjectionDefinition} from './expression/types/projection_definition';
-import createVisibilityExpression from './expression/visibility';
+import createVisibilityExpression, {type VisibilityExpression} from './expression/visibility';
 
 type ExpressionType =
     | 'data-driven'
@@ -222,6 +222,9 @@ export type {
     SourceExpression,
     CompositeExpression,
     StylePropertyExpression,
+    DiffCommand,
+    DiffOperations,
+    FeatureFilter,
     IMercatorCoordinate,
     ICanonicalTileID,
     ILngLat,
@@ -252,6 +255,7 @@ export {
     StylePropertyFunction,
     ZoomDependentExpression,
     FormatExpression,
+    VisibilityExpression,
     latest,
     validateStyleMin,
     groupByLayout,


### PR DESCRIPTION
this addresses issue #1637. There were four Typescript items used by maplibre-gl recent versions and missing from the index.d.ts file:
- DiffCommand (type)
- DiffOperations (type)
- FeatureFilter (type)
- VisibilityExpression (interface, imported as type)

Each of these was imported from the appropriate file (added to the existing imports) and added to the appropriate list at the end of src/index.ts. 

expression/visibility.ts has a default export as well as the export of interface VisibilityExpression, so the import needed 'type' to clarify that VisibilityExpression is only used as a type. The default import, 'createVisibility()', is renamed in the import to 'createVisibilityExpression'.

Verified that the generated index.d.ts includes all of the types above, and that 'createVisibility' is renamed (by exporting with 'as createVisibilityExpression').

There are some warnings about node:fs when building, but they were also there in the base.

All tests complete without error. Nothing added to tests.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
