### PR TITLE
docs: Fix Stretch Properties JSON example

### DIFF
--- a/docs/sprite.md
+++ b/docs/sprite.md
@@ -93,12 +93,13 @@ The following image gives a bit more infomation regarding the stretch properties
         "height": 30,
         "x": 0,
         "y": 0,
-        "stretchX": [[5, 10], [15, 20]]
-        "stretchY": [[5, 20]]
+        "stretchX": [[5, 10], [15, 20]],
+        "stretchY": [[5, 20]],
         "pixelRatio": 1
     }
 }
 ```
+
 The red highlighted part is where the stretch will occur over the Y axis and the blue highlight is for the X axis.
 ![popup-stretch](https://maplibre.org/maplibre-gl-js/docs/assets/popup_debug.png)
 


### PR DESCRIPTION
Fix invalid JSON syntax in the _Stretch Properties_ example (https://maplibre.org/maplibre-style-spec/sprite/#stretch-properties).

Add Missing JSON Commas. The example is missing trailing commas for `stretchX` and `stretchY`, which makes the JSON invalid if copied directly.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
