### PR TITLE
fix: resolve global-state to null for unset key when other keys are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐞 Bug fixes
 - _...Add new stuff here..._
+- Resolve `["global-state", key]` to `null` instead of `undefined` when the key is unset but other global state keys are set ([#1531](https://github.com/maplibre/maplibre-style-spec/issues/1531))
 
 ## 24.8.5
 

--- a/src/expression/definitions/global_state.ts
+++ b/src/expression/definitions/global_state.ts
@@ -40,7 +40,7 @@ export class GlobalState implements Expression {
 
         if (!globalState || Object.keys(globalState).length === 0) return null;
 
-        return getOwn(globalState, this.key);
+        return getOwn(globalState, this.key) ?? null;
     }
 
     eachChild() {}

--- a/test/integration/expression/tests/global-state/unset-with-other-keys/test.json
+++ b/test/integration/expression/tests/global-state/unset-with-other-keys/test.json
@@ -1,0 +1,30 @@
+{
+  "expression": [
+    "==",
+    [
+      "global-state",
+      "x"
+    ],
+    null
+  ],
+  "inputs": [
+    [
+      {},
+      {}
+    ]
+  ],
+  "globalState": {
+    "y": true
+  },
+  "expected": {
+    "compiled": {
+      "result": "success",
+      "isFeatureConstant": true,
+      "isZoomConstant": true,
+      "type": "boolean"
+    },
+    "outputs": [
+      true
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #1531.

`["global-state", key]` returned `undefined` instead of `null` when the requested key was not set but some other global state key was, because `getOwn` returns `undefined` for a missing key. This made comparisons like `["==", ["global-state", key], null]` evaluate to `false` once an unrelated key existed. Coalescing the lookup with `?? null` matches the documented behaviour, as suggested in the issue.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
