### PR TITLE
chore: fix lint warnings

### DIFF
--- a/src/expression/types/color_array.test.ts
+++ b/src/expression/types/color_array.test.ts
@@ -43,6 +43,6 @@ describe('ColorArray', () => {
 
         expect(() => {
             ColorArray.interpolate(colorArray, targetColorArray, 0.5);
-        }).toThrowError('colorArray: Arrays have mismatched length (2 vs. 1), cannot interpolate.');
+        }).toThrow('colorArray: Arrays have mismatched length (2 vs. 1), cannot interpolate.');
     });
 });

--- a/src/expression/types/variable_anchor_offset_collection.test.ts
+++ b/src/expression/types/variable_anchor_offset_collection.test.ts
@@ -39,12 +39,12 @@ describe('VariableAnchorOffsetCollection', () => {
         test('should throw with mismatched endpoints', () => {
             expect(() =>
                 i11nFn(parseFn(['top', [0, 0]]), parseFn(['bottom', [1, 1]]), 0.5)
-            ).toThrowError(
+            ).toThrow(
                 'Cannot interpolate values containing mismatched anchors. from[0]: top, to[0]: bottom'
             );
             expect(() =>
                 i11nFn(parseFn(['top', [0, 0]]), parseFn(['top', [1, 1], 'bottom', [2, 2]]), 0.5)
-            ).toThrowError(
+            ).toThrow(
                 'Cannot interpolate values of different length. from: ["top",[0,0]], to: ["top",[1,1],"bottom",[2,2]]'
             );
         });

--- a/src/expression/visibility.test.ts
+++ b/src/expression/visibility.test.ts
@@ -3,7 +3,7 @@ import {describe, test, expect, vi} from 'vitest';
 
 describe('create visibility expression', () => {
     test('throws Error for invalid function', () => {
-        expect(() => createVisibilityExpression(['bla'] as any, {})).toThrowError(
+        expect(() => createVisibilityExpression(['bla'] as any, {})).toThrow(
             'Unknown expression "bla". If you wanted a literal array, use ["literal", [...]].'
         );
     });

--- a/src/feature_filter/feature_filter.test.ts
+++ b/src/feature_filter/feature_filter.test.ts
@@ -88,15 +88,15 @@ describe('filter', () => {
     test('expression, type error', () => {
         expect(() => {
             featureFilter(['==', ['number', ['get', 'x']], ['string', ['get', 'y']]]);
-        }).toThrowError(": Cannot compare types 'number' and 'string'.");
+        }).toThrow(": Cannot compare types 'number' and 'string'.");
 
         expect(() => {
             featureFilter(['number', ['get', 'x']]);
-        }).toThrowError(': Expected boolean but found number instead.');
+        }).toThrow(': Expected boolean but found number instead.');
 
         expect(() => {
             featureFilter(['boolean', ['get', 'x']]);
-        }).not.toThrowError();
+        }).not.toThrow();
     });
 
     test('expression, within', () => {

--- a/src/function/index.test.ts
+++ b/src/function/index.test.ts
@@ -284,7 +284,7 @@ describe('exponential function', () => {
                     type: 'color'
                 }
             );
-        }).toThrowError('Unknown color space: "invalid"');
+        }).toThrow('Unknown color space: "invalid"');
     });
 
     test('exponential interpolation of colorArray', () => {
@@ -367,7 +367,7 @@ describe('exponential function', () => {
                     type: 'colorArray'
                 }
             );
-        }).toThrowError('Unknown color space: "invalid"');
+        }).toThrow('Unknown color space: "invalid"');
     });
 
     test('exponential interpolation of numberArray', () => {
@@ -1536,7 +1536,7 @@ test('unknown function', () => {
                 type: 'string'
             }
         )
-    ).toThrowError(/Unknown function type "nonesuch"/);
+    ).toThrow(/Unknown function type "nonesuch"/);
 });
 
 describe('kind', () => {

--- a/src/migrate.test.ts
+++ b/src/migrate.test.ts
@@ -9,13 +9,13 @@ describe('migrate', () => {
     test('does not migrate from version 5', () => {
         expect(() => {
             migrate({version: 5, layers: []} as any);
-        }).toThrowError('Cannot migrate from 5');
+        }).toThrow('Cannot migrate from 5');
     });
 
     test('does not migrate from version 6', () => {
         expect(() => {
             migrate({version: 6, layers: []} as any);
-        }).toThrowError('Cannot migrate from 6');
+        }).toThrow('Cannot migrate from 6');
     });
 
     test('migrates to latest version from version 7', () => {
@@ -181,7 +181,7 @@ describe('migrate', () => {
             ]
         };
 
-        expect(() => migrate(style)).not.toThrowError();
+        expect(() => migrate(style)).not.toThrow();
         expect(style.layers[0].paint).toEqual({
             'icon-color': 'hsl(100,30%,20%)',
             'icon-opacity-transition': {duration: 0}


### PR DESCRIPTION
## Launch Checklist

Fixes lint warnings, this was done automatically by eslint.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
