### PR TITLE
has filter returns false for undefined property values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- `has` filter now returns `false` when a property exists but is set to `undefined` ([#1712](https://github.com/maplibre/maplibre-style-spec/pull/1712)) (by [@xavierjs](https://github.com/xavierjs))
 - _...Add new stuff here..._
 
 ## 25.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@types/node": "^25.9.3",
         "@typescript-eslint/eslint-plugin": "^8.61.0",
         "@typescript-eslint/parser": "^8.61.0",
-        "@typescript/native-preview": "*",
+        "@typescript/native-preview": "beta",
         "@vitest/coverage-v8": "4.1.8",
         "@vitest/eslint-plugin": "^1.6.20",
         "@vitest/ui": "4.1.8",

--- a/src/expression/compound_expression.ts
+++ b/src/expression/compound_expression.ts
@@ -428,7 +428,15 @@ CompoundExpression.register(expressions, {
             return typeof a === typeof b && a >= b;
         }
     ],
-    'filter-has': [BooleanType, [ValueType], (ctx, [k]) => { const key = (k as any).value; const props = ctx.properties(); return key in props && props[key] !== undefined; }],
+    'filter-has': [
+        BooleanType,
+        [ValueType],
+        (ctx, [k]) => {
+            const key = (k as any).value;
+            const props = ctx.properties();
+            return key in props && props[key] !== undefined;
+        }
+    ],
     'filter-has-id': [BooleanType, [], (ctx) => ctx.id() !== null && ctx.id() !== undefined],
     'filter-type-in': [
         BooleanType,

--- a/src/expression/compound_expression.ts
+++ b/src/expression/compound_expression.ts
@@ -194,7 +194,7 @@ function rgba(ctx, [r, g, b, a]) {
 }
 
 function has(key, obj) {
-    return key in obj;
+    return key in obj && obj[key] !== undefined;
 }
 
 function get(key, obj) {
@@ -428,7 +428,7 @@ CompoundExpression.register(expressions, {
             return typeof a === typeof b && a >= b;
         }
     ],
-    'filter-has': [BooleanType, [ValueType], (ctx, [k]) => (k as any).value in ctx.properties()],
+    'filter-has': [BooleanType, [ValueType], (ctx, [k]) => { const key = (k as any).value; const props = ctx.properties(); return key in props && props[key] !== undefined; }],
     'filter-has-id': [BooleanType, [], (ctx) => ctx.id() !== null && ctx.id() !== undefined],
     'filter-type-in': [
         BooleanType,

--- a/src/feature_filter/feature_filter.test.ts
+++ b/src/feature_filter/feature_filter.test.ts
@@ -646,7 +646,7 @@ describe('legacy filter tests', () => {
             expect(f({zoom: 0}, {properties: {foo: true}} as any as Feature)).toBe(true);
             expect(f({zoom: 0}, {properties: {foo: false}} as any as Feature)).toBe(true);
             expect(f({zoom: 0}, {properties: {foo: null}} as any as Feature)).toBe(true);
-            expect(f({zoom: 0}, {properties: {foo: undefined}} as any as Feature)).toBe(true);
+            expect(f({zoom: 0}, {properties: {foo: undefined}} as any as Feature)).toBe(false);
             expect(f({zoom: 0}, {properties: {}} as any as Feature)).toBe(false);
         });
 
@@ -658,7 +658,7 @@ describe('legacy filter tests', () => {
             expect(f({zoom: 0}, {properties: {foo: false}} as any as Feature)).toBe(false);
             expect(f({zoom: 0}, {properties: {foo: false}} as any as Feature)).toBe(false);
             expect(f({zoom: 0}, {properties: {foo: null}} as any as Feature)).toBe(false);
-            expect(f({zoom: 0}, {properties: {foo: undefined}} as any as Feature)).toBe(false);
+            expect(f({zoom: 0}, {properties: {foo: undefined}} as any as Feature)).toBe(true);
             expect(f({zoom: 0}, {properties: {}} as any as Feature)).toBe(true);
         });
     }

--- a/src/feature_filter/feature_filter.test.ts
+++ b/src/feature_filter/feature_filter.test.ts
@@ -645,7 +645,9 @@ describe('legacy filter tests', () => {
             expect(f({zoom: 0}, {properties: {foo: '0'}} as any as Feature)).toBe(true);
             expect(f({zoom: 0}, {properties: {foo: true}} as any as Feature)).toBe(true);
             expect(f({zoom: 0}, {properties: {foo: false}} as any as Feature)).toBe(true);
+            // null is a valid JSON value, property exists
             expect(f({zoom: 0}, {properties: {foo: null}} as any as Feature)).toBe(true);
+            // undefined means the property was never set, treated as absent
             expect(f({zoom: 0}, {properties: {foo: undefined}} as any as Feature)).toBe(false);
             expect(f({zoom: 0}, {properties: {}} as any as Feature)).toBe(false);
         });
@@ -657,7 +659,9 @@ describe('legacy filter tests', () => {
             expect(f({zoom: 0}, {properties: {foo: '0'}} as any as Feature)).toBe(false);
             expect(f({zoom: 0}, {properties: {foo: false}} as any as Feature)).toBe(false);
             expect(f({zoom: 0}, {properties: {foo: false}} as any as Feature)).toBe(false);
+            // null is a valid JSON value, property exists
             expect(f({zoom: 0}, {properties: {foo: null}} as any as Feature)).toBe(false);
+            // undefined means the property was never set, treated as absent
             expect(f({zoom: 0}, {properties: {foo: undefined}} as any as Feature)).toBe(true);
             expect(f({zoom: 0}, {properties: {}} as any as Feature)).toBe(true);
         });


### PR DESCRIPTION
A property set to `undefined` is semantically equivalent to a missing property. The `get` expression already returns `null` for `undefined` values, so `has` should be consistent and return `false` in that case. This is the behavious of filtering in previous Maplibre (like the 5.6.10)

`has` and `filter-has` expressions now return `false` when a property exists but is set to `undefined`, treating it the same as a missing property
Previously, `has` only checked `key in obj`, which returned `true` for properties explicitly set to `undefined`                                                                                                                                   

 - [X] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Include before/after visuals or gifs if this PR includes visual changes.
 - [X] Write tests for all new functionality.
 - [X] Document any changes to public APIs.
 - [X] Post benchmark scores.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
