### PR TITLE
fix: legacy+expression filter error suggests a broken expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐞 Bug fixes
 - `has` filter now returns `false` when a property exists but is set to `undefined` ([#1712](https://github.com/maplibre/maplibre-style-spec/pull/1712)) (by [@xavierjs](https://github.com/xavierjs))
+- Fix incorrect replacement suggestion in error messages for mixed legacy+expression `$type` filters ([#1727](https://github.com/maplibre/maplibre-style-spec/pull/1727)) (by [@ciscorn](https://github.com/ciscorn))
 - _...Add new stuff here..._
 
 ## 25.0.0

--- a/src/feature_filter/feature_filter.test.ts
+++ b/src/feature_filter/feature_filter.test.ts
@@ -797,7 +797,19 @@ describe('global-state in filter', () => {
         ] as unknown as ExpressionFilterSpecification;
 
         expect(() => featureFilter(filter, globalState)).toThrow(
-            'Mixing deprecated filter syntax with expression syntax is not supported. Replace ["==","$type","Polygon"] with ["==",["in",["geometry-type"],["literal",["Polygon","MultiPolygon"]]]].'
+            'Mixing deprecated filter syntax with expression syntax is not supported. Replace ["==","$type","Polygon"] with ["in",["geometry-type"],["literal",["Polygon","MultiPolygon"]]].'
+        );
+    });
+
+    test('suggests a valid expression for mixed "$type" != filter', () => {
+        const filter = [
+            'all',
+            ['!=', '$type', 'LineString'],
+            ['==', ['global-state', 'active'], true]
+        ] as unknown as ExpressionFilterSpecification;
+
+        expect(() => featureFilter(filter, {active: true})).toThrow(
+            'Mixing deprecated filter syntax with expression syntax is not supported. Replace ["!=","$type","LineString"] with ["!",["in",["geometry-type"],["literal",["LineString","MultiLineString"]]]].'
         );
     });
 });

--- a/src/feature_filter/index.ts
+++ b/src/feature_filter/index.ts
@@ -95,10 +95,13 @@ function getLegacyFilterExpressionSuggestion(filter: Array<any>): unknown {
         case '>=':
             if (filter.length !== 3 || typeof filter[1] !== 'string') return null;
             if (filter[1] === '$type') {
-                return [
-                    filter[0],
-                    ['in', ['geometry-type'], ['literal', [filter[2], `Multi${filter[2]}`]]]
+                if (filter[0] !== '==' && filter[0] !== '!=') return null;
+                const expression = [
+                    'in',
+                    ['geometry-type'],
+                    ['literal', [filter[2], `Multi${filter[2]}`]]
                 ];
+                return filter[0] === '!=' ? ['!', expression] : expression;
             }
             return [filter[0], getFilterPropertyExpression(filter[1]), filter[2]];
 

--- a/test/integration/style-spec/tests/filters.output.json
+++ b/test/integration/style-spec/tests/filters.output.json
@@ -56,7 +56,7 @@
     "line": 152
   },
   {
-    "message": "layers[15].filter[1]: Mixing deprecated filter syntax with expression syntax is not supported. Replace [\"==\",\"$type\",\"Point\"] with [\"==\",[\"in\",[\"geometry-type\"],[\"literal\",[\"Point\",\"MultiPoint\"]]]].",
+    "message": "layers[15].filter[1]: Mixing deprecated filter syntax with expression syntax is not supported. Replace [\"==\",\"$type\",\"Point\"] with [\"in\",[\"geometry-type\"],[\"literal\",[\"Point\",\"MultiPoint\"]]].",
     "line": 159
   },
   {
@@ -68,7 +68,7 @@
     "line": 173
   },
   {
-    "message": "layers[18].filter[1][2]: Mixing deprecated filter syntax with expression syntax is not supported. Replace [\"==\",\"$type\",\"Point\"] with [\"==\",[\"in\",[\"geometry-type\"],[\"literal\",[\"Point\",\"MultiPoint\"]]]].",
+    "message": "layers[18].filter[1][2]: Mixing deprecated filter syntax with expression syntax is not supported. Replace [\"==\",\"$type\",\"Point\"] with [\"in\",[\"geometry-type\"],[\"literal\",[\"Point\",\"MultiPoint\"]]].",
     "line": 180
   },
   {


### PR DESCRIPTION
Follow-up to #1709 

I found the mixed legacy+expression filter error (#1709) can suggest invalid expressions for "$type" filters. It emits a one-argument `["==", ["in", ...]]`.

The fix suggests the bare `["in", ...]` for `"=="` and `["!", ["in", ...]]` for `"!="`.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] ~Include before/after visuals or gifs if this PR includes visual changes.~
 - [x] Write tests for all new functionality.
 - [ ] ~Document any changes to public APIs.~
 - [ ] ~Post benchmark scores.~
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
