### PR TITLE
fix: simplify legacy+expression $type filter suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🐞 Bug fixes
 - `has` filter now returns `false` when a property exists but is set to `undefined` ([#1712](https://github.com/maplibre/maplibre-style-spec/pull/1712)) (by [@xavierjs](https://github.com/xavierjs))
-- Fix incorrect replacement suggestion in error messages for mixed legacy+expression `$type` filters ([#1727](https://github.com/maplibre/maplibre-style-spec/pull/1727)) (by [@ciscorn](https://github.com/ciscorn))
+- Fix incorrect replacement suggestion in error messages for mixed legacy+expression `$type` filters ([#1727](https://github.com/maplibre/maplibre-style-spec/pull/1727), [#XXXX](https://github.com/maplibre/maplibre-style-spec/pull/XXXX)) (by [@ciscorn](https://github.com/ciscorn))
 - _...Add new stuff here..._
 
 ## 25.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🐞 Bug fixes
 - `has` filter now returns `false` when a property exists but is set to `undefined` ([#1712](https://github.com/maplibre/maplibre-style-spec/pull/1712)) (by [@xavierjs](https://github.com/xavierjs))
-- Fix incorrect replacement suggestion in error messages for mixed legacy+expression `$type` filters ([#1727](https://github.com/maplibre/maplibre-style-spec/pull/1727), [#XXXX](https://github.com/maplibre/maplibre-style-spec/pull/XXXX)) (by [@ciscorn](https://github.com/ciscorn))
+- Fix incorrect replacement suggestion in error messages for mixed legacy+expression `$type` filters ([#1727](https://github.com/maplibre/maplibre-style-spec/pull/1727), [#1728](https://github.com/maplibre/maplibre-style-spec/pull/1728)) (by [@ciscorn](https://github.com/ciscorn))
 - _...Add new stuff here..._
 
 ## 25.0.0

--- a/src/feature_filter/feature_filter.test.ts
+++ b/src/feature_filter/feature_filter.test.ts
@@ -797,7 +797,7 @@ describe('global-state in filter', () => {
         ] as unknown as ExpressionFilterSpecification;
 
         expect(() => featureFilter(filter, globalState)).toThrow(
-            'Mixing deprecated filter syntax with expression syntax is not supported. Replace ["==","$type","Polygon"] with ["in",["geometry-type"],["literal",["Polygon","MultiPolygon"]]].'
+            'Mixing deprecated filter syntax with expression syntax is not supported. Replace ["==","$type","Polygon"] with ["==",["geometry-type"],"Polygon"].'
         );
     });
 
@@ -809,7 +809,7 @@ describe('global-state in filter', () => {
         ] as unknown as ExpressionFilterSpecification;
 
         expect(() => featureFilter(filter, {active: true})).toThrow(
-            'Mixing deprecated filter syntax with expression syntax is not supported. Replace ["!=","$type","LineString"] with ["!",["in",["geometry-type"],["literal",["LineString","MultiLineString"]]]].'
+            'Mixing deprecated filter syntax with expression syntax is not supported. Replace ["!=","$type","LineString"] with ["!=",["geometry-type"],"LineString"].'
         );
     });
 });

--- a/src/feature_filter/index.ts
+++ b/src/feature_filter/index.ts
@@ -81,6 +81,7 @@ export function isExpressionFilter(filter: any): filter is ExpressionFilterSpeci
 }
 
 function getFilterPropertyExpression(property: string): unknown {
+    if (property === '$type') return ['geometry-type'];
     if (property === '$id') return ['id'];
     return ['get', property];
 }
@@ -94,39 +95,16 @@ function getLegacyFilterExpressionSuggestion(filter: Array<any>): unknown {
         case '>':
         case '>=':
             if (filter.length !== 3 || typeof filter[1] !== 'string') return null;
-            if (filter[1] === '$type') {
-                if (filter[0] !== '==' && filter[0] !== '!=') return null;
-                const expression = [
-                    'in',
-                    ['geometry-type'],
-                    ['literal', [filter[2], `Multi${filter[2]}`]]
-                ];
-                return filter[0] === '!=' ? ['!', expression] : expression;
-            }
             return [filter[0], getFilterPropertyExpression(filter[1]), filter[2]];
 
         case 'in':
         case '!in': {
             if (filter.length < 2 || typeof filter[1] !== 'string') return null;
-            let expression = [
+            const expression = [
                 'in',
                 getFilterPropertyExpression(filter[1]),
                 ['literal', filter.slice(2)]
             ];
-            if (filter[1] === '$type') {
-                expression = [
-                    'in',
-                    ['geometry-type'],
-                    [
-                        'literal',
-                        filter
-                            .slice(2)
-                            .map((g) => [g, `Multi${g}`])
-                            .flat()
-                    ]
-                ];
-            }
-
             return filter[0] === '!in' ? ['!', expression] : expression;
         }
 

--- a/test/integration/style-spec/tests/filters.output.json
+++ b/test/integration/style-spec/tests/filters.output.json
@@ -56,7 +56,7 @@
     "line": 152
   },
   {
-    "message": "layers[15].filter[1]: Mixing deprecated filter syntax with expression syntax is not supported. Replace [\"==\",\"$type\",\"Point\"] with [\"in\",[\"geometry-type\"],[\"literal\",[\"Point\",\"MultiPoint\"]]].",
+    "message": "layers[15].filter[1]: Mixing deprecated filter syntax with expression syntax is not supported. Replace [\"==\",\"$type\",\"Point\"] with [\"==\",[\"geometry-type\"],\"Point\"].",
     "line": 159
   },
   {
@@ -64,11 +64,11 @@
     "line": 166
   },
   {
-    "message": "layers[17].filter[1]: Mixing deprecated filter syntax with expression syntax is not supported. Replace [\"in\",\"$type\",\"Point\",\"LineString\"] with [\"in\",[\"geometry-type\"],[\"literal\",[\"Point\",\"MultiPoint\",\"LineString\",\"MultiLineString\"]]].",
+    "message": "layers[17].filter[1]: Mixing deprecated filter syntax with expression syntax is not supported. Replace [\"in\",\"$type\",\"Point\",\"LineString\"] with [\"in\",[\"geometry-type\"],[\"literal\",[\"Point\",\"LineString\"]]].",
     "line": 173
   },
   {
-    "message": "layers[18].filter[1][2]: Mixing deprecated filter syntax with expression syntax is not supported. Replace [\"==\",\"$type\",\"Point\"] with [\"in\",[\"geometry-type\"],[\"literal\",[\"Point\",\"MultiPoint\"]]].",
+    "message": "layers[18].filter[1][2]: Mixing deprecated filter syntax with expression syntax is not supported. Replace [\"==\",\"$type\",\"Point\"] with [\"==\",[\"geometry-type\"],\"Point\"].",
     "line": 180
   },
   {


### PR DESCRIPTION
More follow-up to #1727, #1709.

@HarelM's comment https://github.com/maplibre/maplibre-style-spec/pull/1727#issuecomment-4790855282:
> I think this was reported as a wrong suggestion as $type and geometry-type are acting the same, so there's no need for the literal and "in" complexity...

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - ~[ ] Include before/after visuals or gifs if this PR includes visual changes.~
 - [x] Write tests for all new functionality.
 - ~[ ] Document any changes to public APIs.~
 - ~[ ] Post benchmark scores.~
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.