### PR TITLE
Add fill-extrusion-edge-radius layout property

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -91,6 +91,7 @@ function validSchema(k, v, obj, ref, version, kind) {
         'default',
         'doc',
         'example',
+        'experimental',
         'function',
         'zoom-function',
         'property-function',

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -1145,6 +1145,23 @@
         ]
       },
       "property-type": "data-constant"
+    },
+    "fill-extrusion-edge-radius": {
+      "type": "number",
+      "experimental": true,
+      "default": 0,
+      "minimum": 0,
+      "doc": "Radius of a fill extrusion edge in meters. If not zero, rounds extrusion edges for a smoother appearance.",
+      "sdk-support": {
+        "basic functionality": {}
+      },
+      "expression": {
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
+      },
+      "property-type": "constant"
     }
   },
   "layout_line": {

--- a/src/validate/validate_fill_extrusion_edge_radius.test.ts
+++ b/src/validate/validate_fill_extrusion_edge_radius.test.ts
@@ -36,9 +36,7 @@ describe('fill-extrusion-edge-radius validation', () => {
     });
 
     test('accepts a non-interpolated zoom camera expression', () => {
-        const errors = validateStyleMin(
-            styleWithEdgeRadius(['step', ['zoom'], 0, 14, 4])
-        );
+        const errors = validateStyleMin(styleWithEdgeRadius(['step', ['zoom'], 0, 14, 4]));
         expect(errors).toHaveLength(0);
     });
 

--- a/src/validate/validate_fill_extrusion_edge_radius.test.ts
+++ b/src/validate/validate_fill_extrusion_edge_radius.test.ts
@@ -1,0 +1,64 @@
+import {validateStyleMin} from '../validate_style.min';
+import {describe, test, expect} from 'vitest';
+import type {StyleSpecification} from '../types.g';
+
+function styleWithEdgeRadius(edgeRadius: unknown): StyleSpecification {
+    return {
+        version: 8,
+        sources: {
+            geojson: {
+                type: 'geojson',
+                data: {type: 'FeatureCollection', features: []}
+            }
+        },
+        layers: [
+            {
+                id: 'buildings',
+                type: 'fill-extrusion',
+                source: 'geojson',
+                layout: {
+                    'fill-extrusion-edge-radius': edgeRadius
+                }
+            }
+        ]
+    } as StyleSpecification;
+}
+
+describe('fill-extrusion-edge-radius validation', () => {
+    test('accepts a constant number', () => {
+        const errors = validateStyleMin(styleWithEdgeRadius(8));
+        expect(errors).toHaveLength(0);
+    });
+
+    test('accepts the default of 0', () => {
+        const errors = validateStyleMin(styleWithEdgeRadius(0));
+        expect(errors).toHaveLength(0);
+    });
+
+    test('accepts a non-interpolated zoom camera expression', () => {
+        const errors = validateStyleMin(
+            styleWithEdgeRadius(['step', ['zoom'], 0, 14, 4])
+        );
+        expect(errors).toHaveLength(0);
+    });
+
+    test('rejects an interpolate expression (property is non-interpolated)', () => {
+        const errors = validateStyleMin(
+            styleWithEdgeRadius(['interpolate', ['linear'], ['zoom'], 14, 0, 16, 4])
+        );
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toMatch(/fill-extrusion-edge-radius/);
+    });
+
+    test('rejects a string value', () => {
+        const errors = validateStyleMin(styleWithEdgeRadius('wide'));
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toMatch(/fill-extrusion-edge-radius/);
+    });
+
+    test('rejects a negative value below the minimum', () => {
+        const errors = validateStyleMin(styleWithEdgeRadius(-3));
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toMatch(/fill-extrusion-edge-radius/);
+    });
+});


### PR DESCRIPTION
## What this adds

An experimental, non-interpolated constant layout property `fill-extrusion-edge-radius` (number, meters, default `0`, minimum `0`) on the `fill-extrusion` layer. A non-zero radius rounds a building footprint's corners at bucket build time, producing a smoother silhouette and smoother facade normals. The default 0 leaves geometry byte-identical to today's output - existing styles and deployments see no change.

This PR also introduces the `experimental` property attribute to the reference schema (this is the first property to use it) and teaches the schema test to accept it. Happy to split that into a separate PR if preferred.

## Relationship to Mapbox GL JS v3

The property name and concept follow Mapbox GL JS v3's public API for ecosystem familiarity, but the semantics were designed independently: the value is expressed in meters rather than a 0–1 value, and Mapbox's `maximum: 1` cap is deliberately omitted so real-world corner radii above one meter are expressible (the renderer guards degenerate inputs - sharp turns, short edges, triangles - at the geometry level). The spec text and the implementation are original; no Mapbox code or spec text was referenced or copied.

## Implementation

A complete renderer implementation ships alongside this spec change in maplibre-native (maplibre/maplibre-native#4379), including render tests proving byte-identical output at radius 0. A maplibre-gl-js implementation of the same algorithm exists and will follow as its own PR, so the property lands with native + web parity.

Will be raising the same for maplibre-js in next few days.

## Launch Checklist

 - [x] Confirm no Mapbox backports
 - [x] Describe changes
 - [x] Related issues - (maplibre/maplibre-native#4379)
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
