### PR TITLE
feat: export v8 types inferred by typescript

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -21,6 +21,8 @@ jobs:
       - run: npm ci
       - run: npm run lint
         if: success() || failure()
+      - run: npm run build
+        if: success() || failure()
       - run: npm run typecheck
         if: success() || failure()
   unit-and-integration-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## main
 ### ✨ Features and improvements
+
+- Add v8.json types called `StyleSpecificationReference` ([#1767](https://github.com/maplibre/maplibre-style-spec/issues/1767)) (by [@HarelM](https://github.com/HarelM))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Fix index.d.ts file wrong json import ([#1767](https://github.com/maplibre/maplibre-style-spec/issues/1767)) (by [@HarelM](https://github.com/HarelM))
 - _...Add new stuff here..._
 
 ## 26.0.0

--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -1,6 +1,6 @@
 import v8 from '../src/reference/v8.json' with {type: 'json'};
 import fs from 'fs';
-import {formatJSON} from './util';
+import {formatJSON} from './util.ts';
 
 /**
  * This script generates markdown documentation from the JSON schema.

--- a/build/generate-style-spec.ts
+++ b/build/generate-style-spec.ts
@@ -1,7 +1,7 @@
 import {writeFileSync} from 'fs';
 import spec from '../src/reference/v8.json' with {type: 'json'};
-import {supportsPropertyExpression, supportsZoomExpression} from '../src/util/properties';
-import {formatJSON} from './util';
+import {supportsPropertyExpression, supportsZoomExpression} from '../src/util/properties.ts';
+import {formatJSON} from './util.ts';
 
 function jsDocComment(property) {
     const lines = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "rolldown": "^1.1.5",
         "rolldown-plugin-dts": "^0.27.7",
         "semver": "^7.8.5",
-        "ts-node": "^10.9.2",
         "tslib": "^2.8.1",
         "typescript": "^6.0.3",
         "vitest": "4.1.10"
@@ -103,28 +102,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1090,30 +1067,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
@@ -2096,15 +2049,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2130,12 +2074,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2209,12 +2147,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
-    },
     "node_modules/cross-env": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
@@ -2279,15 +2211,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/dts-resolver": {
@@ -3243,12 +3166,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
-    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -3874,49 +3791,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3965,12 +3839,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
     },
     "node_modules/vite": {
       "version": "8.1.4",
@@ -4170,15 +4038,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "type": "module",
   "scripts": {
     "build": "npm run generate-style-spec && rolldown -c rolldown.config.ts && cp ./src/reference/v8.json ./dist/latest.json",
-    "generate-style-spec": "node --no-warnings --loader ts-node/esm build/generate-style-spec.ts",
+    "generate-style-spec": "node build/generate-style-spec.ts",
     "generate-typings": "cross-env BUILD=types rolldown -c rolldown.config.ts",
-    "generate-docs": "node ${WATCH+--watch} --no-warnings --loader ts-node/esm build/generate-docs.ts",
+    "generate-docs": "node ${WATCH+--watch} build/generate-docs.ts",
     "start-docs": "docker run --rm -v ${PWD}:/docs zensical/zensical serve --open",
     "docs": "npm run generate-docs && docker run --rm -v ${PWD}:/docs zensical/zensical build",
     "test": "npm run test-unit && npm run test-integration && npm run test-build",
@@ -80,7 +80,6 @@
     "rolldown": "^1.1.5",
     "rolldown-plugin-dts": "^0.27.7",
     "semver": "^7.8.5",
-    "ts-node": "^10.9.2",
     "tslib": "^2.8.1",
     "typescript": "^6.0.3",
     "vitest": "4.1.10"

--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -11,8 +11,8 @@ const dtsBundle: RolldownOptions = {
         dir: 'dist',
         format: 'es'
     },
-    external: [...Object.keys(packageJSON.dependencies), /\.json$/],
-    plugins: [dts({emitDtsOnly: true, tsgo: true})]
+    external: [...Object.keys(packageJSON.dependencies)],
+    plugins: [dts({emitDtsOnly: true, tsgo: false})]
 };
 
 const bundles: RolldownOptions[] = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
-import v8Spec from './reference/v8.json' with {type: 'json'};
-const v8 = v8Spec as any;
-import latest from './reference/latest';
+import {latest, type StyleSpecificationReference} from './reference/latest';
 import {derefLayers} from './deref';
 import {diff, type DiffCommand, type DiffOperations} from './diff';
 import {ValidationError, type ValidationSeverity} from './error/validation_error';
@@ -235,7 +233,8 @@ export type {
     VerticalAlign,
     Point2D,
     Expression,
-    ValidationSeverity
+    ValidationSeverity,
+    StyleSpecificationReference
 };
 
 export {
@@ -262,6 +261,7 @@ export {
     VisibilityExpression,
     FormattedSection,
     latest,
+    latest as v8,
     validateStyleMin,
     groupByLayout,
     emptyStyle,
@@ -288,7 +288,6 @@ export {
     ProjectionDefinitionType,
     ColorType,
     interpolateFactory as interpolates,
-    v8,
     NullType,
     styleFunction as function,
     visit,

--- a/src/reference/latest.ts
+++ b/src/reference/latest.ts
@@ -1,3 +1,10 @@
-import latest from './v8.json' with {type: 'json'};
+import v8 from './v8.json' with {type: 'json'};
+
+/**
+ * The style specification reference, i.e. the contents of `v8.json`, Inferred from the JSON itself.
+ */
+export type StyleSpecificationReference = typeof v8;
+
+const latest: StyleSpecificationReference = v8;
+
 export {latest};
-export default latest as any;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "outDir": "dist",
     "allowSyntheticDefaultImports": true,
     "checkJs": true,
     "isolatedModules": false,
-    "noEmit": false,
     "declaration": false,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "importHelpers": false,
     "jsx": "react",
@@ -18,10 +18,6 @@
     "target": "ES2019",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "types": ["node", "geojson"]
-  },
-  "ts-node": {
-    "experimentalSpecifierResolution": "node",
-    "esm": true
   },
   "include": ["rolldown.config.*", "src/**/*", "build/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Launch Checklist

- Replaces #1766

This exports the types created by typescript from reading the v8.json file.
This is created automatically, but tsgo still doesn't support this, so we revert to using regular typescript.
The CI never validated the index.d.ts file, which is why it never failed, I've added the relevant step to make sure we validate the d.ts file as well as part of the build.
I removed ts-node as modern node version doesn't need it anymore.

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
