### PR TITLE
fix: missing interpolation type in style function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- _...Add new stuff here..._
+- Restore missing `interpolationType`, `globalStateRefs` and `isStateDependent` fields on legacy stop functions ([#1768](https://github.com/maplibre/maplibre-style-spec/pull/1768)) (by [@HarelM](https://github.com/HarelM))
 
 ## 26.0.0
 

--- a/src/expression/index.test.ts
+++ b/src/expression/index.test.ts
@@ -1,4 +1,10 @@
-import {normalizePropertyExpression, StyleExpression} from '.';
+import {
+    normalizePropertyExpression,
+    StyleExpression,
+    StylePropertyFunction,
+    type CameraExpression,
+    type StylePropertyExpression
+} from '.';
 import {StylePropertySpecification} from '..';
 import {Color} from './types/color';
 import {ColorArray} from './types/color_array';
@@ -194,5 +200,44 @@ describe('StyleExpressions', () => {
         expect(params).toHaveProperty('globalState', {x: 5});
         expect(params).not.toHaveProperty('a');
         expect(params).not.toHaveProperty('b');
+    });
+});
+
+describe('StylePropertyFunction', () => {
+    const interpolatableSpec: StylePropertySpecification = {
+        type: 'number',
+        default: 16,
+        'property-type': 'data-driven',
+        expression: {interpolated: true, parameters: ['zoom', 'feature']},
+        transition: false
+    } as StylePropertySpecification;
+
+    test('exposes interpolationType for a legacy camera function that is zoom-interpolatable', () => {
+        const expression = normalizePropertyExpression(
+            {base: 1.4, stops: [[10, 8], [20, 14]]},
+            'layers[0].layout.text-size',
+            interpolatableSpec
+        ) as StylePropertyFunction<number>;
+
+        expect(expression.kind).toBe('camera');
+        expect(expression.zoomStops).toEqual([10, 20]);
+        expect(expression.interpolationType).toEqual({name: 'exponential', base: 1.4});
+        expect(expression.globalStateRefs.has('foo')).toBe(false);
+        expect(expression.globalStateRefs.size).toBe(0);
+        expect(expression.isStateDependent).toBe(false);
+    });
+
+    test('preserves interpolationType across a serialize/deserialize round trip', () => {
+        const original = new StylePropertyFunction(
+            {base: 1.4, stops: [[10, 8], [20, 14]]},
+            'layers[0].layout.text-size',
+            interpolatableSpec
+        );
+        const roundTripped = StylePropertyFunction.deserialize(
+            StylePropertyFunction.serialize(original)
+        );
+
+        expect(roundTripped.interpolationType).toEqual({name: 'exponential', base: 1.4});
+        expect(roundTripped.zoomStops).toEqual([10, 20]);
     });
 });

--- a/src/expression/index.test.ts
+++ b/src/expression/index.test.ts
@@ -1,8 +1,4 @@
-import {
-    normalizePropertyExpression,
-    StyleExpression,
-    StylePropertyFunction
-} from '.';
+import {normalizePropertyExpression, StyleExpression, StylePropertyFunction} from '.';
 import {StylePropertySpecification} from '..';
 import {Color} from './types/color';
 import {ColorArray} from './types/color_array';

--- a/src/expression/index.test.ts
+++ b/src/expression/index.test.ts
@@ -214,7 +214,13 @@ describe('StylePropertyFunction', () => {
 
     test('exposes interpolationType for a legacy camera function that is zoom-interpolatable', () => {
         const expression = normalizePropertyExpression(
-            {base: 1.4, stops: [[10, 8], [20, 14]]},
+            {
+                base: 1.4,
+                stops: [
+                    [10, 8],
+                    [20, 14]
+                ]
+            },
             'layers[0].layout.text-size',
             interpolatableSpec
         ) as StylePropertyFunction<number>;
@@ -229,7 +235,13 @@ describe('StylePropertyFunction', () => {
 
     test('preserves interpolationType across a serialize/deserialize round trip', () => {
         const original = new StylePropertyFunction(
-            {base: 1.4, stops: [[10, 8], [20, 14]]},
+            {
+                base: 1.4,
+                stops: [
+                    [10, 8],
+                    [20, 14]
+                ]
+            },
             'layers[0].layout.text-size',
             interpolatableSpec
         );

--- a/src/expression/index.test.ts
+++ b/src/expression/index.test.ts
@@ -1,9 +1,7 @@
 import {
     normalizePropertyExpression,
     StyleExpression,
-    StylePropertyFunction,
-    type CameraExpression,
-    type StylePropertyExpression
+    StylePropertyFunction
 } from '.';
 import {StylePropertySpecification} from '..';
 import {Color} from './types/color';

--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -1,7 +1,6 @@
 import {ExpressionParsingError} from './parsing_error';
 import {ParsingContext} from './parsing_context';
 import {EvaluationContext} from './evaluation_context';
-
 import {
     CompoundExpression,
     isFeatureConstant,
@@ -9,13 +8,18 @@ import {
     isStateConstant,
     isExpressionConstant
 } from './compound_expression';
-
 import {Step} from './definitions/step';
 import {Interpolate} from './definitions/interpolate';
 import {Coalesce} from './definitions/coalesce';
 import {Let} from './definitions/let';
 import {expressions} from './definitions';
-
+import {Color} from './types/color';
+import {Padding} from './types/padding';
+import {NumberArray} from './types/number_array';
+import {ColorArray} from './types/color_array';
+import {VariableAnchorOffsetCollection} from './types/variable_anchor_offset_collection';
+import {ProjectionDefinition} from './types/projection_definition';
+import {GlobalState} from './definitions/global_state';
 import {RuntimeError} from './runtime_error';
 import {success, error} from '../util/result';
 import {
@@ -23,7 +27,6 @@ import {
     supportsZoomExpression,
     supportsInterpolation
 } from '../util/properties';
-
 import {
     ColorType,
     StringType,
@@ -41,11 +44,17 @@ import {
     NumberArrayType,
     ColorArrayType
 } from './types';
+import {ICanonicalTileID} from '../tiles_and_coordinates';
+import {isFunction, createFunction} from '../function';
+
 import type {Value} from './values';
 import type {Expression} from './expression';
-import {type StylePropertySpecification} from '..';
+import type {StylePropertySpecification} from '..';
 import type {Result} from '../util/result';
 import type {InterpolationType} from './definitions/interpolate';
+import type {FormattedSection} from './types/formatted';
+import type {Point2D} from '../point2d';
+import type {StyleFunction} from '../function';
 import type {
     PaddingSpecification,
     NumberArraySpecification,
@@ -53,18 +62,6 @@ import type {
     PropertyValueSpecification,
     VariableAnchorOffsetCollectionSpecification
 } from '../types.g';
-import type {FormattedSection} from './types/formatted';
-import type {Point2D} from '../point2d';
-
-import {ICanonicalTileID} from '../tiles_and_coordinates';
-import {isFunction, createFunction} from '../function';
-import {Color} from './types/color';
-import {Padding} from './types/padding';
-import {NumberArray} from './types/number_array';
-import {ColorArray} from './types/color_array';
-import {VariableAnchorOffsetCollection} from './types/variable_anchor_offset_collection';
-import {ProjectionDefinition} from './types/projection_definition';
-import {GlobalState} from './definitions/global_state';
 
 export type Feature = {
     readonly type:
@@ -589,9 +586,13 @@ export class StylePropertyFunction<T> {
     _warningHistory: {[key: string]: boolean};
     _innerEvaluate: (globals: GlobalProperties, feature?: Feature) => any;
 
-    kind: EvaluationKind;
+    kind: StyleFunction['kind'];
     interpolationFactor: (input: number, lower: number, upper: number) => number;
     zoomStops: Array<number>;
+    interpolationType: InterpolationType | null;
+    isStateDependent: boolean = false; // Legacy functions cannot reference feature state or global state, so these are constant.
+    globalStateRefs: Set<string> = new Set<string>();
+    readonly _globalState: Record<string, any> = null;
 
     constructor(
         parameters: PropertyValueSpecification<T>,
@@ -609,7 +610,7 @@ export class StylePropertyFunction<T> {
         this.kind = fn.kind;
         this.interpolationFactor = fn.interpolationFactor;
         this.zoomStops = fn.zoomStops;
-        // Kept off the instance so it doesn't shadow the error-handling `evaluate` method
+        this.interpolationType = fn.interpolationType;
         this._innerEvaluate = fn.evaluate;
     }
 
@@ -668,7 +669,7 @@ export function normalizePropertyExpression<T>(
     globalState?: Record<string, any>
 ): StylePropertyExpression {
     if (isFunction(value)) {
-        return new StylePropertyFunction(value, rootKey, specification) as any;
+        return new StylePropertyFunction(value, rootKey, specification);
     } else if (isExpression(value)) {
         const expression = createPropertyExpression(value, rootKey, specification, globalState);
         if (expression.result === 'error') {


### PR DESCRIPTION
## Launch Checklist

- Fixes an issue with a missed field that was copied by extendBy in #1740

This is why extendBy should not be used...

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
