### PR TITLE
fix: normalize multi-geometry types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Match multi-geometries with their simple type in geometry filters ([#1346](https://github.com/maplibre/maplibre-style-spec/issues/1346)) (by [@Guflly](https://github.com/Guflly))
 - _...Add new stuff here..._
 
 ## 26.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- Match multi-geometries with their simple type in geometry filters ([#1346](https://github.com/maplibre/maplibre-style-spec/issues/1346)) (by [@Guflly](https://github.com/Guflly))
+- Match multi-geometries with their simple type in geometry filters ([#1800](https://github.com/maplibre/maplibre-style-spec/pull/1800)) (by [@Guflly](https://github.com/Guflly))
 - _...Add new stuff here..._
 
 ## 26.2.1

--- a/src/expression/evaluation_context.ts
+++ b/src/expression/evaluation_context.ts
@@ -30,11 +30,12 @@ export class EvaluationContext {
     }
 
     geometryType() {
-        return this.feature
-            ? typeof this.feature.type === 'number'
+        if (!this.feature) return null;
+        const type =
+            typeof this.feature.type === 'number'
                 ? geometryTypes[this.feature.type]
-                : this.feature.type
-            : null;
+                : this.feature.type;
+        return type.startsWith('Multi') ? type.slice(5) : type;
     }
 
     geometry() {

--- a/src/feature_filter/feature_filter.test.ts
+++ b/src/feature_filter/feature_filter.test.ts
@@ -116,6 +116,27 @@ describe('filter', () => {
         expect(match(undefined, {properties: {x: 'd'}} as any as Feature)).toBe(false);
     });
 
+    test.each([
+        {type: 'Point', multiType: 'MultiPoint'},
+        {type: 'LineString', multiType: 'MultiLineString'},
+        {type: 'Polygon', multiType: 'MultiPolygon'}
+    ])('expression, geometry type normalizes $multiType', ({type, multiType}) => {
+        const filter = featureFilter(
+            ['==', ['geometry-type'], type],
+            'layers[0].filter'
+        ).filter;
+        expect(filter({zoom: 0}, {type} as any as Feature)).toBe(true);
+        expect(filter({zoom: 0}, {type: multiType} as any as Feature)).toBe(true);
+    });
+
+    test('expression, geometry type rejects a missing feature', () => {
+        const filter = featureFilter(
+            ['==', ['geometry-type'], 'Point'],
+            'layers[0].filter'
+        ).filter;
+        expect(filter({zoom: 0}, undefined)).toBe(false);
+    });
+
     test('expression, type error', () => {
         expect(() => {
             featureFilter(

--- a/src/feature_filter/feature_filter.test.ts
+++ b/src/feature_filter/feature_filter.test.ts
@@ -121,19 +121,13 @@ describe('filter', () => {
         {type: 'LineString', multiType: 'MultiLineString'},
         {type: 'Polygon', multiType: 'MultiPolygon'}
     ])('expression, geometry type normalizes $multiType', ({type, multiType}) => {
-        const filter = featureFilter(
-            ['==', ['geometry-type'], type],
-            'layers[0].filter'
-        ).filter;
+        const filter = featureFilter(['==', ['geometry-type'], type], 'layers[0].filter').filter;
         expect(filter({zoom: 0}, {type} as any as Feature)).toBe(true);
         expect(filter({zoom: 0}, {type: multiType} as any as Feature)).toBe(true);
     });
 
     test('expression, geometry type rejects a missing feature', () => {
-        const filter = featureFilter(
-            ['==', ['geometry-type'], 'Point'],
-            'layers[0].filter'
-        ).filter;
+        const filter = featureFilter(['==', ['geometry-type'], 'Point'], 'layers[0].filter').filter;
         expect(filter({zoom: 0}, undefined)).toBe(false);
     });
 

--- a/src/feature_filter/feature_filter.test.ts
+++ b/src/feature_filter/feature_filter.test.ts
@@ -334,9 +334,12 @@ describe('legacy filter tests', () => {
         });
 
         test('==, $type', () => {
-            const f = createFilterExpr(['==', '$type', 'LineString']).filter;
-            expect(f({zoom: 0}, {type: 1} as any as Feature)).toBe(false);
-            expect(f({zoom: 0}, {type: 2} as any as Feature)).toBe(true);
+            const f = createFilterExpr(['==', '$type', 'Polygon']).filter;
+            expect(f({zoom: 0}, {type: 2} as any as Feature)).toBe(false);
+            expect(f({zoom: 0}, {type: 3} as any as Feature)).toBe(true);
+            expect(f({zoom: 0}, {type: 'Polygon'} as any as Feature)).toBe(true);
+            expect(f({zoom: 0}, {type: 'LineString'} as any as Feature)).toBe(false);
+            expect(f({zoom: 0}, {type: 'MultiPolygon'} as any as Feature)).toBe(true);
         });
 
         test('==, $id', () => {


### PR DESCRIPTION
Fixes #1346.

String geometry types now use the same Multi* normalization as numeric GeoJSON types. This makes `$type == Polygon` match `MultiPolygon` while keeping unrelated types false. Regression coverage exercises both feature-filter paths.

AI assistance: I used an LLM to help implement the fix and regression test. I reviewed the full diff and ran all checks.

Tests:
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run typecheck`
- `npx oxfmt --check src/expression/evaluation_context.ts src/feature_filter/feature_filter.test.ts`

## Launch Checklist

- [x] These changes do not include backports from Mapbox projects.
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [x] No visual changes.
- [x] Write tests for all new functionality.
- [x] No public API documentation changes are needed.
- [x] No benchmark changes are expected.
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.