### PR TITLE
Publish a module-per-file ESM build so bundlers can tree-shake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 ### ✨ Features and improvements
 - _...Add new stuff here..._
+- Publish the ESM build (`dist/index.mjs`, referenced by `package.json#module`) as one module per source file instead of a single bundle, so that bundlers which eliminate dead code at module granularity can drop unused parts of the package ([#1829](https://github.com/maplibre/maplibre-style-spec/pull/1829)) (by [@ahocevar](https://github.com/ahocevar))
 
 ### 🐞 Bug fixes
 - _...Add new stuff here..._

--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -23,8 +23,12 @@ const bundles: RolldownOptions[] = [
         input: './src/index.ts',
         output: [
             {
-                file: 'dist/index.mjs',
+                dir: 'dist',
                 format: 'es',
+                preserveModules: true,
+                preserveModulesRoot: 'src',
+                entryFileNames: '[name].mjs',
+                chunkFileNames: '[name].mjs',
                 sourcemap: true
             },
             {

--- a/test/build/style-spec.test.ts
+++ b/test/build/style-spec.test.ts
@@ -6,7 +6,7 @@ import {spawnSync} from 'node:child_process';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {describe, test, expect} from 'vitest';
-const minBundle = fs.readFileSync('dist/index.mjs', 'utf8');
+const refBundle = fs.readFileSync('dist/reference/v8.mjs', 'utf8');
 const validStyle = JSON.stringify({version: 8, sources: {}, layers: []});
 
 describe('@maplibre/maplibre-gl-style-spec npm package', () => {
@@ -30,7 +30,26 @@ describe('@maplibre/maplibre-gl-style-spec npm package', () => {
         expect(dirContents).toContain('index.mjs');
         expect(dirContents).toContain('index.mjs.map');
         expect(dirContents).toContain('latest.json');
-        expect(dirContents).toHaveLength(18);
+        expect(dirContents).toHaveLength(43);
+    });
+
+    test('index.mjs is a module-per-file build, not a single bundle', async () => {
+        // The point of building with `preserveModules` is that consumers can
+        // drop what they do not import, which only works if the modules that
+        // `dist/index.mjs` imports stay separate files alongside it.
+        const dirContents = await readdir('dist');
+        expect(dirContents).toContain('deref.mjs');
+        expect(dirContents).toContain('expression');
+        expect(fs.statSync('dist/index.mjs').size).toBeLessThan(5000);
+    });
+
+    test('cjs build exports the same names as the esm build', async () => {
+        const cjs = await import('../../dist/index.cjs');
+        const esm = await import('../../dist/index.mjs');
+        // The UMD build adds a synthetic `default` export pointing at itself,
+        // which the esm build has no equivalent for.
+        const cjsNames = Object.keys(cjs).filter((name) => name !== 'default');
+        expect(Object.keys(esm).sort()).toEqual(cjsNames.sort());
     });
 
     test('exports components directly, not behind `default` - https://github.com/mapbox/mapbox-gl-js/issues/6601', async () => {
@@ -39,7 +58,7 @@ describe('@maplibre/maplibre-gl-style-spec npm package', () => {
 
     test('trims reference.json fields', () => {
         expect(latest.$root.version.doc).toBeTruthy();
-        expect(minBundle.includes(latest.$root.version.doc)).toBeFalsy();
+        expect(refBundle.includes(latest.$root.version.doc)).toBeFalsy();
     });
 
     test('"latest" entry point should be defined', async () => {


### PR DESCRIPTION
`dist/index.mjs` is a single module. `"sideEffects": false` in `package.json` therefore has not really anything to act on for bundlers that eliminate dead code at *module* granularity.

For example, an app that only needs one small helper:

```js
import {derefLayers} from '@maplibre/maplibre-gl-style-spec';
```

got the whole package back, minified (26.2.1):

- rollup: 65,021 bytes
- webpack 5: 129,379 bytes

rollup does better because it also does statement-level elimination inside a module, whereas webpack only can remove dead code at the module level. But even rollup cannot drop everything, because the module has top-level side effects (`CompoundExpression.register`).

This pull request suggests adding an ESM output (built with `preserveModules`) to `dist/esm/`, and point `package.json`'s `module` property at it.

With this change, with the same import, bundlers can do a much better job:

```js
import {derefLayers} from '@maplibre/maplibre-gl-style-spec';
```

now resolves through `dist/esm` instead of `dist/index.mjs`, minified:

- rollup: 65,021 → **477 bytes**
- webpack 5: 129,379 → **407 bytes**

webpack now matches rollup — the fix isn't webpack-specific, it helps any bundler once an app uses less than the full surface.

To benefit from treeshaking even more, 2b41151a47f8f4ab0919554ee9963ed52c51d61b replaces an `instanceof` chain in the constant analysis with two optional `Expression` flags, so `compound_expression.ts` no longer needs to hard-references `Within`, `Distance`, `CollatorExpression` and `GlobalState` just for the `instanceof` check. This adjustment is worth ~14.7 kB minified.


## AI disclosure

The build configuration change, the refactor and the test additions were drafted with AI assistance (Claude). 


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Write tests for all new functionality.
 - [x] Document any changes to public APIs.
 - [x] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
