### PR TITLE
Enable data-driven `icon-rotation-alignment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main
 ### ✨ Features and improvements
+- Enable data-driven styling for `icon-rotation-alignment` (by [@Turbo87](https://github.com/Turbo87))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -1693,6 +1693,11 @@
           "android": "2.0.1",
           "ios": "2.0.0"
         },
+        "data-driven styling": {
+          "js": "https://github.com/maplibre/maplibre-gl-js/issues/3461",
+          "android": "https://github.com/maplibre/maplibre-native/issues/4517",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/4517"
+        },
         "`auto` value": {
           "js": "0.25.0",
           "android": "4.2.0",
@@ -1707,10 +1712,11 @@
       "expression": {
         "interpolated": false,
         "parameters": [
-          "zoom"
+          "zoom",
+          "feature"
         ]
       },
-      "property-type": "data-constant"
+      "property-type": "data-driven"
     },
     "icon-size": {
       "type": "number",


### PR DESCRIPTION
This enables feature expressions for `icon-rotation-alignment`, allowing a symbol layer to select map or viewport alignment for individual icons. The SDK support metadata tracks the corresponding GL JS implementation and the remaining Android and iOS work.

## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license).
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [ ] Include before/after visuals or gifs if this PR includes visual changes. Not applicable to this metadata change.
- [ ] Write tests for all new functionality.
- [ ] Document any changes to public APIs.
- [ ] Post benchmark scores. Not applicable to this metadata change.
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.

## Related

- https://github.com/maplibre/maplibre-gl-js/issues/3461
- maplibre/maplibre-gl-js#8121
- maplibre/maplibre-native#4517