### PR TITLE
Update vertical gradient property for fill extr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 ### ✨ Features and improvements
 - Allow negative `fill-extrusion-base` and `fill-extrusion-height` values, extruding below ground level (e.g. underground floors) ([maplibre-gl-js#8051](https://github.com/maplibre/maplibre-gl-js/issues/8051)) (by [@clement-igonet](https://github.com/clement-igonet))
+- Make `fill-extrusion-vertical-gradient` configurable: in addition to a boolean, it now also accepts a `[depth, referenceHeight]` array so the shading effect no longer has to be scaled by a hardcoded 150 meter reference height ([#1795](https://github.com/maplibre/maplibre-style-spec/issues/1795))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/build/generate-docs.ts
+++ b/build/generate-docs.ts
@@ -321,6 +321,7 @@ function typeToMarkdownLink(type: string): string {
         case 'padding':
         case 'numberarray':
         case 'colorarray':
+        case 'verticalgradient':
             return ` [${type}](types.md#${type.toLocaleLowerCase()})`;
         case 'filter':
             return ` [${type}](expressions.md)`;

--- a/build/generate-style-spec.ts
+++ b/build/generate-style-spec.ts
@@ -184,6 +184,7 @@ export type ProjectionDefinitionSpecification = string | ProjectionDefinitionT |
 export type PaddingSpecification = number | number[];
 export type NumberArraySpecification = number | number[];
 export type ColorArraySpecification = string | string[];
+export type VerticalGradientSpecification = boolean | number[];
 
 export type VariableAnchorOffsetCollectionSpecification = Array<string | [number, number]>;
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -228,3 +228,20 @@ A single color value, or an array of color values.
     "hillshade-highlight-color": ["#ffff00", "rgb(255, 255, 0)", "yellow"]
 }
 ```
+
+## `verticalGradient`
+
+A boolean, or a `[depth, referenceHeight]` array of one or two numbers:
+
+- `depth` (in range `[0, 1]`) controls how dark the foot of a wall gets. `0` disables shading, `0.5` matches what `true` applies, and `1` doubles it.
+- `referenceHeight` (in meters, defaults to `0` when omitted) controls whether the shading is scaled by building height: `0` shades every building equally, and a positive value restores the height-scaled behavior that `true` applies above `150`.
+
+`true` is equivalent to `[0.5, 150]` and `false` is equivalent to `[0, 0]`.
+
+```json
+{
+    "fill-extrusion-vertical-gradient": true,
+    "fill-extrusion-vertical-gradient": [0.7],
+    "fill-extrusion-vertical-gradient": [0.7, 100]
+}
+```

--- a/src/expression/definitions/coercion.ts
+++ b/src/expression/definitions/coercion.ts
@@ -9,6 +9,7 @@ import {NumberArray} from '../types/number_array';
 import {ColorArray} from '../types/color_array';
 import {VariableAnchorOffsetCollection} from '../types/variable_anchor_offset_collection';
 import {ProjectionDefinition} from '../types/projection_definition';
+import {VerticalGradient} from '../types/vertical_gradient';
 
 import type {Expression} from '../expression';
 import type {ParsingContext} from '../parsing_context';
@@ -151,6 +152,21 @@ export class Coercion implements Expression {
                 }
                 throw new RuntimeError(
                     `Could not parse variableAnchorOffsetCollection from value '${typeof input === 'string' ? input : JSON.stringify(input)}'`,
+                    this.key
+                );
+            }
+            case 'verticalGradient': {
+                let input;
+                for (const arg of this.args) {
+                    input = arg.evaluate(ctx);
+
+                    const gradient = VerticalGradient.parse(input);
+                    if (gradient) {
+                        return gradient;
+                    }
+                }
+                throw new RuntimeError(
+                    `Could not parse verticalGradient from value '${typeof input === 'string' ? input : JSON.stringify(input)}'`,
                     this.key
                 );
             }

--- a/src/expression/expression.test.ts
+++ b/src/expression/expression.test.ts
@@ -423,6 +423,18 @@ describe('actionable warnings: fallback rendering', () => {
         ).toBe("rk: Could not parse numberArray from value 'notarray' Falling back to [1,2,3].");
     });
 
+    test('verticalGradient default renders as a JSON array', () => {
+        expect(
+            warnFor(
+                ['get', 'g'],
+                {type: 'verticalGradient', default: true} as any as StylePropertySpecification,
+                {g: 'notagradient'}
+            )
+        ).toBe(
+            "rk: Could not parse verticalGradient from value 'notagradient' Falling back to [0.5,150]."
+        );
+    });
+
     test('projectionDefinition default renders as a string', () => {
         expect(
             warnFor(

--- a/src/expression/index.ts
+++ b/src/expression/index.ts
@@ -19,6 +19,7 @@ import {NumberArray} from './types/number_array';
 import {ColorArray} from './types/color_array';
 import {VariableAnchorOffsetCollection} from './types/variable_anchor_offset_collection';
 import {ProjectionDefinition} from './types/projection_definition';
+import {VerticalGradient} from './types/vertical_gradient';
 import {GlobalState} from './definitions/global_state';
 import {RuntimeError} from './runtime_error';
 import {success, error} from '../util/result';
@@ -42,7 +43,8 @@ import {
     type EvaluationKind,
     ProjectionDefinitionType,
     NumberArrayType,
-    ColorArrayType
+    ColorArrayType,
+    VerticalGradientType
 } from './types';
 import {ICanonicalTileID} from '../tiles_and_coordinates';
 import {isFunction, createFunction} from '../function';
@@ -60,7 +62,8 @@ import type {
     NumberArraySpecification,
     ColorArraySpecification,
     PropertyValueSpecification,
-    VariableAnchorOffsetCollectionSpecification
+    VariableAnchorOffsetCollectionSpecification,
+    VerticalGradientSpecification
 } from '../types.g';
 
 export type Feature = {
@@ -705,6 +708,11 @@ export function normalizePropertyExpression<T>(
             );
         } else if (specification.type === 'projectionDefinition' && typeof value === 'string') {
             constant = ProjectionDefinition.parse(value);
+        } else if (
+            specification.type === 'verticalGradient' &&
+            (typeof value === 'boolean' || Array.isArray(value))
+        ) {
+            constant = VerticalGradient.parse(value as VerticalGradientSpecification);
         }
         return {
             globalStateRefs: new Set<string>(),
@@ -788,7 +796,8 @@ function getExpectedType(spec: StylePropertySpecification): Type {
         colorArray: ColorArrayType,
         projectionDefinition: ProjectionDefinitionType,
         resolvedImage: ResolvedImageType,
-        variableAnchorOffsetCollection: VariableAnchorOffsetCollectionType
+        variableAnchorOffsetCollection: VariableAnchorOffsetCollectionType,
+        verticalGradient: VerticalGradientType
     };
 
     if (spec.type === 'array') {
@@ -818,6 +827,8 @@ function getDefaultValue(spec: StylePropertySpecification): Value {
             return VariableAnchorOffsetCollection.parse(spec.default) || null;
         case 'projectionDefinition':
             return ProjectionDefinition.parse(spec.default) || null;
+        case 'verticalGradient':
+            return VerticalGradient.parse(spec.default) || null;
         default:
             return spec.default === undefined ? null : spec.default;
     }

--- a/src/expression/parsing_context.ts
+++ b/src/expression/parsing_context.ts
@@ -148,7 +148,9 @@ export class ParsingContext {
                         ('colorArray' === expected.kind &&
                             ['value', 'string', 'array'].includes(actual.kind)) ||
                         ('variableAnchorOffsetCollection' === expected.kind &&
-                            ['value', 'array'].includes(actual.kind))
+                            ['value', 'array'].includes(actual.kind)) ||
+                        ('verticalGradient' === expected.kind &&
+                            ['value', 'boolean', 'array'].includes(actual.kind))
                     ) {
                         parsed = annotate(parsed, expected, options.typeAnnotation || 'coerce');
                     } else if (this.checkSubtype(expected, actual)) {

--- a/src/expression/types.ts
+++ b/src/expression/types.ts
@@ -46,6 +46,9 @@ export type ResolvedImageTypeT = {
 export type VariableAnchorOffsetCollectionTypeT = {
     kind: 'variableAnchorOffsetCollection';
 };
+export type VerticalGradientTypeT = {
+    kind: 'verticalGradient';
+};
 
 export type EvaluationKind = 'constant' | 'source' | 'camera' | 'composite';
 
@@ -66,7 +69,8 @@ export type Type =
     | NumberArrayTypeT
     | ColorArrayTypeT
     | ResolvedImageTypeT
-    | VariableAnchorOffsetCollectionTypeT;
+    | VariableAnchorOffsetCollectionTypeT
+    | VerticalGradientTypeT;
 
 export interface ArrayType<T extends Type = Type> {
     kind: 'array';
@@ -96,6 +100,7 @@ export const ResolvedImageType = {kind: 'resolvedImage'} as ResolvedImageTypeT;
 export const VariableAnchorOffsetCollectionType = {
     kind: 'variableAnchorOffsetCollection'
 } as VariableAnchorOffsetCollectionTypeT;
+export const VerticalGradientType = {kind: 'verticalGradient'} as VerticalGradientTypeT;
 
 export function array<T extends Type>(itemType: T, N?: number | null): ArrayType<T> {
     return {
@@ -132,7 +137,8 @@ const valueMemberTypes = [
     NumberArrayType,
     ColorArrayType,
     ResolvedImageType,
-    VariableAnchorOffsetCollectionType
+    VariableAnchorOffsetCollectionType,
+    VerticalGradientType
 ];
 
 /**

--- a/src/expression/types/vertical_gradient.test.ts
+++ b/src/expression/types/vertical_gradient.test.ts
@@ -1,0 +1,27 @@
+import {VerticalGradient} from './vertical_gradient';
+import {describe, test, expect} from 'vitest';
+
+describe('VerticalGradient', () => {
+    test('VerticalGradient.parse', () => {
+        expect(VerticalGradient.parse()).toBeUndefined();
+        expect(VerticalGradient.parse(null)).toBeUndefined();
+        expect(VerticalGradient.parse(undefined)).toBeUndefined();
+        expect(VerticalGradient.parse('true' as any)).toBeUndefined();
+        expect(VerticalGradient.parse([])).toBeUndefined();
+        expect(VerticalGradient.parse([1, 2, 3])).toBeUndefined();
+        expect(VerticalGradient.parse([1, '2'] as any)).toBeUndefined();
+
+        expect(VerticalGradient.parse(true)).toEqual(new VerticalGradient(0.5, 150));
+        expect(VerticalGradient.parse(false)).toEqual(new VerticalGradient(0, 0));
+        expect(VerticalGradient.parse([0.7])).toEqual(new VerticalGradient(0.7, 0));
+        expect(VerticalGradient.parse([0.7, 100])).toEqual(new VerticalGradient(0.7, 100));
+
+        const passThru = new VerticalGradient(0.5, 150);
+        expect(VerticalGradient.parse(passThru)).toBe(passThru);
+    });
+
+    test('VerticalGradient#toString', () => {
+        const verticalGradient = new VerticalGradient(0.5, 150);
+        expect(verticalGradient.toString()).toBe('[0.5,150]');
+    });
+});

--- a/src/expression/types/vertical_gradient.ts
+++ b/src/expression/types/vertical_gradient.ts
@@ -1,0 +1,51 @@
+/**
+ * Configuration for the vertical shading applied to the sides of a fill-extrusion layer.
+ * Create instances from a boolean or a `[depth, referenceHeight]` array using the static
+ * method `VerticalGradient.parse`.
+ * @private
+ */
+export class VerticalGradient {
+    /** How dark the foot of a wall gets, in the range [0, 1]. */
+    depth: number;
+    /** The building height, in meters, above which the shading reaches full `depth`; `0` shades every building equally. */
+    referenceHeight: number;
+
+    constructor(depth: number, referenceHeight: number) {
+        this.depth = depth;
+        this.referenceHeight = referenceHeight;
+    }
+
+    /**
+     * @param input A vertical gradient value
+     * @returns A `VerticalGradient` instance, or `undefined` if the input is not a valid vertical gradient value.
+     */
+    static parse(
+        input?: boolean | number[] | VerticalGradient | null
+    ): VerticalGradient | undefined {
+        if (input instanceof VerticalGradient) {
+            return input;
+        }
+
+        // Backwards compatibility: `true` matches the previously hardcoded shading,
+        // `false` disables it.
+        if (typeof input === 'boolean') {
+            return input ? new VerticalGradient(0.5, 150) : new VerticalGradient(0, 0);
+        }
+
+        if (!Array.isArray(input) || input.length < 1 || input.length > 2) {
+            return undefined;
+        }
+
+        for (const val of input) {
+            if (typeof val !== 'number') {
+                return undefined;
+            }
+        }
+
+        return new VerticalGradient(input[0], input.length > 1 ? input[1] : 0);
+    }
+
+    toString(): string {
+        return JSON.stringify([this.depth, this.referenceHeight]);
+    }
+}

--- a/src/expression/values.ts
+++ b/src/expression/values.ts
@@ -7,6 +7,7 @@ import {ColorArray} from './types/color_array';
 import {VariableAnchorOffsetCollection} from './types/variable_anchor_offset_collection';
 import {ResolvedImage} from './types/resolved_image';
 import {ProjectionDefinition} from './types/projection_definition';
+import {VerticalGradient} from './types/vertical_gradient';
 import {
     NullType,
     NumberType,
@@ -23,7 +24,8 @@ import {
     NumberArrayType,
     ColorArrayType,
     VariableAnchorOffsetCollectionType,
-    ProjectionDefinitionType
+    ProjectionDefinitionType,
+    VerticalGradientType
 } from './types';
 
 import type {Type} from './types';
@@ -67,6 +69,7 @@ export type Value =
     | ColorArray
     | ResolvedImage
     | VariableAnchorOffsetCollection
+    | VerticalGradient
     | ReadonlyArray<Value>
     | {
           readonly [x: string]: Value;
@@ -86,7 +89,8 @@ export function isValue(mixed: unknown): boolean {
         mixed instanceof NumberArray ||
         mixed instanceof ColorArray ||
         mixed instanceof VariableAnchorOffsetCollection ||
-        mixed instanceof ResolvedImage
+        mixed instanceof ResolvedImage ||
+        mixed instanceof VerticalGradient
     ) {
         return true;
     } else if (Array.isArray(mixed)) {
@@ -135,6 +139,8 @@ export function typeOf(value: Value): Type {
         return VariableAnchorOffsetCollectionType;
     } else if (value instanceof ResolvedImage) {
         return ResolvedImageType;
+    } else if (value instanceof VerticalGradient) {
+        return VerticalGradientType;
     } else if (Array.isArray(value)) {
         const length = value.length;
         let itemType: Type | typeof undefined;
@@ -171,7 +177,8 @@ export function valueToString(value: Value) {
         value instanceof NumberArray ||
         value instanceof ColorArray ||
         value instanceof VariableAnchorOffsetCollection ||
-        value instanceof ResolvedImage
+        value instanceof ResolvedImage ||
+        value instanceof VerticalGradient
     ) {
         return value.toString();
     } else {

--- a/src/function/index.ts
+++ b/src/function/index.ts
@@ -9,6 +9,7 @@ import {findStopLessThanOrEqualTo} from '../expression/stops';
 import {Padding} from '../expression/types/padding';
 import {ColorArray} from '../expression/types/color_array';
 import {NumberArray} from '../expression/types/number_array';
+import {VerticalGradient} from '../expression/types/vertical_gradient';
 import {typeOf} from '../expression/values';
 import {ObjectType} from '../expression/types';
 import {StylePropertySpecification} from '..';
@@ -46,6 +47,8 @@ function getParseFunction(propertySpec: StylePropertySpecification) {
             return NumberArray.parse;
         case 'colorArray':
             return ColorArray.parse;
+        case 'verticalGradient':
+            return VerticalGradient.parse;
         default:
             return null;
     }
@@ -272,6 +275,9 @@ function evaluateIdentityFunction(parameters, propertySpec, input) {
             break;
         case 'numberArray':
             input = NumberArray.parse(input);
+            break;
+        case 'verticalGradient':
+            input = VerticalGradient.parse(input);
             break;
         default:
             if (

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -82,6 +82,7 @@ function validSchema(k, v, obj, ref, version, kind) {
         'numberArray',
         'colorArray',
         'variableAnchorOffsetCollection',
+        'verticalGradient',
         'sprite',
         'projectionDefinition',
         'state',

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {Padding} from './expression/types/padding';
 import {NumberArray} from './expression/types/number_array';
 import {ColorArray} from './expression/types/color_array';
 import {VariableAnchorOffsetCollection} from './expression/types/variable_anchor_offset_collection';
+import {VerticalGradient} from './expression/types/vertical_gradient';
 import {Formatted, FormattedSection, VerticalAlign} from './expression/types/formatted';
 import {createFunction, isFunction} from './function';
 import {convertFunction} from './function/convert';
@@ -69,7 +70,8 @@ import type {
     NumberArraySpecification,
     ColorArraySpecification,
     ProjectionDefinitionSpecification,
-    VariableAnchorOffsetCollectionSpecification
+    VariableAnchorOffsetCollectionSpecification,
+    VerticalGradientSpecification
 } from './types.g';
 import {format} from './format';
 import {validate} from './validate/validate';
@@ -191,6 +193,13 @@ export type StylePropertySpecification =
           expression?: ExpressionSpecificationDefinition;
           transition: boolean;
           default?: ProjectionDefinitionSpecification;
+      }
+    | {
+          type: 'verticalGradient';
+          'property-type': ExpressionType;
+          expression?: ExpressionSpecificationDefinition;
+          transition: boolean;
+          default?: VerticalGradientSpecification;
       };
 
 const expression = {
@@ -249,6 +258,7 @@ export {
     NumberArray,
     ColorArray,
     VariableAnchorOffsetCollection,
+    VerticalGradient,
     Formatted,
     ResolvedImage,
     EvaluationContext,

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -6970,9 +6970,9 @@
       "property-type": "data-driven"
     },
     "fill-extrusion-vertical-gradient": {
-      "type": "boolean",
+      "type": "verticalGradient",
       "default": true,
-      "doc": "Whether to apply a vertical gradient to the sides of a fill-extrusion layer. If true, sides will be shaded slightly darker farther down.",
+      "doc": "Vertical shading applied to the sides of a fill-extrusion layer. `true` shades the sides slightly darker farther down, scaled by building height so that the effect is only really visible above 150 meters. `false` disables shading. Alternatively, an array of one or two numbers, `[depth, referenceHeight]`. `depth` (0-1) is how dark the foot of a wall gets, as a multiple of the shading `true` applies: 0 disables shading, 0.5 matches `true`, 1 doubles it. `referenceHeight` selects whether the shading is scaled by building height: 0 (the default) shades every building equally, and a positive value in meters restores the height-scaled behaviour above that height, which is what `true` does at 150.",
       "transition": false,
       "sdk-support": {
         "basic functionality": {

--- a/src/validate/validate.ts
+++ b/src/validate/validate.ts
@@ -25,6 +25,7 @@ import {validatePadding} from './validate_padding';
 import {validateNumberArray} from './validate_number_array';
 import {validateColorArray} from './validate_color_array';
 import {validateVariableAnchorOffsetCollection} from './validate_variable_anchor_offset_collection';
+import {validateVerticalGradient} from './validate_vertical_gradient';
 import {validateSprite} from './validate_sprite';
 import {ValidationError} from '../error/validation_error';
 import {validateProjection} from './validate_projection';
@@ -59,6 +60,7 @@ const VALIDATORS = {
     numberArray: validateNumberArray,
     colorArray: validateColorArray,
     variableAnchorOffsetCollection: validateVariableAnchorOffsetCollection,
+    verticalGradient: validateVerticalGradient,
     sprite: validateSprite,
     state: validateState,
     fontFaces: validateFontFaces

--- a/src/validate/validate_vertical_gradient.test.ts
+++ b/src/validate/validate_vertical_gradient.test.ts
@@ -1,0 +1,115 @@
+import {validate} from './validate';
+import {validateVerticalGradient} from './validate_vertical_gradient';
+import {describe, test, expect} from 'vitest';
+
+describe('Validate VerticalGradient', () => {
+    test('Should return error if type is not boolean or array', () => {
+        let errors = validateVerticalGradient({
+            validateSpec: validate,
+            key: 'fill-extrusion-vertical-gradient',
+            value: '3'
+        });
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toBe(
+            'fill-extrusion-vertical-gradient: boolean expected, string found'
+        );
+
+        errors = validateVerticalGradient({
+            validateSpec: validate,
+            key: 'fill-extrusion-vertical-gradient',
+            value: 1
+        });
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toBe(
+            'fill-extrusion-vertical-gradient: boolean expected, number found'
+        );
+
+        errors = validateVerticalGradient({
+            validateSpec: validate,
+            key: 'fill-extrusion-vertical-gradient',
+            value: null
+        });
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toBe(
+            'fill-extrusion-vertical-gradient: boolean expected, null found'
+        );
+    });
+
+    test('Should pass if type is boolean', () => {
+        let errors = validateVerticalGradient({
+            validateSpec: validate,
+            key: 'fill-extrusion-vertical-gradient',
+            value: true
+        });
+        expect(errors).toHaveLength(0);
+
+        errors = validateVerticalGradient({
+            validateSpec: validate,
+            key: 'fill-extrusion-vertical-gradient',
+            value: false
+        });
+        expect(errors).toHaveLength(0);
+    });
+
+    test('Should return error if array length is invalid', () => {
+        let errors = validateVerticalGradient({
+            validateSpec: validate,
+            key: 'fill-extrusion-vertical-gradient',
+            value: []
+        });
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toBe(
+            'fill-extrusion-vertical-gradient: fill-extrusion-vertical-gradient array requires 1 or 2 values; 0 values found'
+        );
+
+        errors = validateVerticalGradient({
+            validateSpec: validate,
+            key: 'fill-extrusion-vertical-gradient',
+            value: [0.5, 150, 1]
+        });
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toBe(
+            'fill-extrusion-vertical-gradient: fill-extrusion-vertical-gradient array requires 1 or 2 values; 3 values found'
+        );
+    });
+
+    test('Should return error if depth is out of range', () => {
+        const errors = validateVerticalGradient({
+            validateSpec: validate,
+            key: 'fill-extrusion-vertical-gradient',
+            value: [1.5]
+        });
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toBe(
+            'fill-extrusion-vertical-gradient[0]: 1.5 is greater than the maximum value 1'
+        );
+    });
+
+    test('Should return error if referenceHeight is negative', () => {
+        const errors = validateVerticalGradient({
+            validateSpec: validate,
+            key: 'fill-extrusion-vertical-gradient',
+            value: [0.5, -10]
+        });
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toBe(
+            'fill-extrusion-vertical-gradient[1]: -10 is less than the minimum value 0'
+        );
+    });
+
+    test('Should pass with a valid array', () => {
+        let errors = validateVerticalGradient({
+            validateSpec: validate,
+            key: 'fill-extrusion-vertical-gradient',
+            value: [0.5]
+        });
+        expect(errors).toHaveLength(0);
+
+        errors = validateVerticalGradient({
+            validateSpec: validate,
+            key: 'fill-extrusion-vertical-gradient',
+            value: [0.5, 150]
+        });
+        expect(errors).toHaveLength(0);
+    });
+});

--- a/src/validate/validate_vertical_gradient.ts
+++ b/src/validate/validate_vertical_gradient.ts
@@ -1,0 +1,48 @@
+import {ValidationError} from '../error/validation_error';
+import {getType} from '../util/get_type';
+import {validateBoolean} from './validate_boolean';
+
+export function validateVerticalGradient(options) {
+    const key = options.key;
+    const value = options.value;
+    const type = getType(value);
+
+    if (type === 'array') {
+        if (value.length < 1 || value.length > 2) {
+            return [
+                new ValidationError(
+                    key,
+                    value,
+                    `fill-extrusion-vertical-gradient array requires 1 or 2 values; ${value.length} values found`
+                )
+            ];
+        }
+
+        let errors = [];
+        errors = errors.concat(
+            options.validateSpec({
+                key: `${key}[0]`,
+                value: value[0],
+                validateSpec: options.validateSpec,
+                valueSpec: {type: 'number', minimum: 0, maximum: 1}
+            })
+        );
+        if (value.length > 1) {
+            errors = errors.concat(
+                options.validateSpec({
+                    key: `${key}[1]`,
+                    value: value[1],
+                    validateSpec: options.validateSpec,
+                    valueSpec: {type: 'number', minimum: 0}
+                })
+            );
+        }
+        return errors;
+    }
+
+    return validateBoolean({
+        key,
+        value,
+        valueSpec: {}
+    });
+}


### PR DESCRIPTION
## Launch Checklist

This PR updates fill-extrusion-vertical-gradient property to adopt https://github.com/maplibre/maplibre-style-spec/issues/1795
Changes are implemented for MapLibre Native: https://github.com/maplibre/maplibre-native/pull/4488

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [X] Briefly describe the changes in this PR.
 - [X] Link to related issues.
 - [X] Include before/after visuals or gifs if this PR includes visual changes.
 - [X] Write tests for all new functionality.
 - [X] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [X] Add an entry to `CHANGELOG.md` under the `## main` section.
