### PR TITLE
ci: cancel superseded pull request runs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -9,6 +9,10 @@ on:
     - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-test-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   bundle-size:
     name: Bundle Size Report

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   code-hygiene:
     name: Code Hygiene


### PR DESCRIPTION
A push to an open pull request starts the test matrix, the docs build and the bundle-size report again while the previous run keeps going. This is the concurrency block the other maplibre repos use (maplibre-tile-spec, martin, maplibre-gl-js in maplibre/maplibre-gl-js#8317): pull request runs are keyed by number and cancelled when superseded; runs on the default branch queue behind each other and are never cancelled.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section (not applicable, CI only).
