### PR TITLE
Document SDK support for SDF fill pattern colorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 ### ✨ Features and improvements
 - Allow negative `fill-extrusion-base` and `fill-extrusion-height` values, extruding below ground level (e.g. underground floors) ([maplibre-gl-js#8051](https://github.com/maplibre/maplibre-gl-js/issues/8051)) (by [@clement-igonet](https://github.com/clement-igonet))
+- Add SDK support tracking for SDF fill pattern colorization ([#1683](https://github.com/maplibre/maplibre-style-spec/pull/1683)) (by [@deniial00](https://github.com/deniial00))
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -6577,6 +6577,11 @@
           "android": "5.0.0",
           "ios": "3.5.0"
         },
+        "SDF fill pattern colorization": {
+          "js": "https://github.com/maplibre/maplibre-style-spec/issues/1642",
+          "android": "https://github.com/maplibre/maplibre-native/issues/4526",
+          "ios": "https://github.com/maplibre/maplibre-native/issues/4526"
+        },
         "[`global-state`](https://maplibre.org/maplibre-style-spec/expressions/#global-state) expression": {
           "js": "5.6.0",
           "android": "https://github.com/maplibre/maplibre-native/issues/3302",

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -6578,7 +6578,7 @@
           "ios": "3.5.0"
         },
         "SDF fill pattern colorization": {
-          "js": "https://github.com/maplibre/maplibre-style-spec/issues/1642",
+          "js": "https://github.com/maplibre/maplibre-gl-js/issues/8342",
           "android": "https://github.com/maplibre/maplibre-native/issues/4526",
           "ios": "https://github.com/maplibre/maplibre-native/issues/4526"
         },


### PR DESCRIPTION
## Description

Adds the missing `sdk-support` entry for SDF fill pattern colorization, following up on #1683. Until implementations are released, the support table links to the existing tracking issues for MapLibre GL JS and MapLibre Native.

This is a documentation metadata change only; it does not alter style validation or runtime behavior.

## Testing

- `npm run lint`
- `npm run generate-docs`
- `npm run test-unit` (644 tests)
- `npm run test-integration` (2223 tests)
- `npm run build`
- `npm run test-build` (15 tests)
- `npm run typecheck`

## Launch Checklist

- [x] Changes do not include backports from Mapbox projects.
- [x] The change is described above.
- [x] Related tracking issues are linked in the support matrix.
- [x] No visual changes.
- [x] No new runtime functionality requiring tests.
- [x] No public API changes.
- [x] No benchmark impact.
- [x] Added an entry to `CHANGELOG.md` under `## main`.

## AI assistance

OpenAI Codex was used to investigate the repository conventions, prepare the metadata change, and run the verification steps. I reviewed and verified the submitted changes.