### PR TITLE
Validate sky transition properties like light does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- Validate `-transition` properties on `sky` the same way `light` already does, so `sky-color-transition` and similar keys no longer report as unknown properties ([maplibre-gl-js#8375](https://github.com/maplibre/maplibre-gl-js/issues/8375)) (by [@Yasser-Ameur](https://github.com/Yasser-Ameur))
+- Validate `-transition` properties on `sky` the same way `light` already does, so `sky-color-transition` and similar keys no longer report as unknown properties ([#1867](https://github.com/maplibre/maplibre-style-spec/pull/1867)) (by [@Yasser-Ameur](https://github.com/Yasser-Ameur))
 - _...Add new stuff here..._
 
 ## 26.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Validate `-transition` properties on `sky` the same way `light` already does, so `sky-color-transition` and similar keys no longer report as unknown properties ([maplibre-gl-js#8375](https://github.com/maplibre/maplibre-gl-js/issues/8375)) (by [@Yasser-Ameur](https://github.com/Yasser-Ameur))
 - _...Add new stuff here..._
 
 ## 26.4.1

--- a/src/util/properties.ts
+++ b/src/util/properties.ts
@@ -14,3 +14,8 @@ export function supportsZoomExpression(spec: StylePropertySpecification): boolea
 export function supportsInterpolation(spec: StylePropertySpecification): boolean {
     return !!spec.expression && spec.expression.interpolated;
 }
+
+/**
+ * Matches a `<property>-transition` key and captures the property it belongs to.
+ */
+export const transitionPropertyRegExp = /^(.*)-transition$/;

--- a/src/validate/validate_light.ts
+++ b/src/validate/validate_light.ts
@@ -1,5 +1,6 @@
 import {ValidationError} from '../error/validation_error';
 import {getType} from '../util/get_type';
+import {transitionPropertyRegExp} from '../util/properties';
 
 export function validateLight(options) {
     const light = options.value;
@@ -20,7 +21,7 @@ export function validateLight(options) {
     }
 
     for (const key in light) {
-        const transitionMatch = key.match(/^(.*)-transition$/);
+        const transitionMatch = key.match(transitionPropertyRegExp);
 
         if (
             transitionMatch &&

--- a/src/validate/validate_property.ts
+++ b/src/validate/validate_property.ts
@@ -2,7 +2,7 @@ import {ValidationError} from '../error/validation_error';
 import {getType} from '../util/get_type';
 import {isFunction} from '../function';
 import {unbundle, deepUnbundle} from '../util/unbundle_jsonlint';
-import {supportsPropertyExpression} from '../util/properties';
+import {supportsPropertyExpression, transitionPropertyRegExp} from '../util/properties';
 
 export function validateProperty(options, propertyType) {
     const key = options.key;
@@ -15,7 +15,7 @@ export function validateProperty(options, propertyType) {
 
     if (!layerSpec) return [];
 
-    const transitionMatch = propertyKey.match(/^(.*)-transition$/);
+    const transitionMatch = propertyKey.match(transitionPropertyRegExp);
     if (
         propertyType === 'paint' &&
         transitionMatch &&

--- a/src/validate/validate_sky.test.ts
+++ b/src/validate/validate_sky.test.ts
@@ -76,14 +76,28 @@ describe('Validate sky', () => {
             validateSpec: validate,
             value: {
                 'sky-color': 'blue',
-                'sky-color-transitionx': {duration: 1000}
+                'not-a-sky-property-transition': {duration: 1000}
             } as any,
             styleSpec: v8,
             style: {} as any
         });
         expect(errors).toHaveLength(1);
-        expect(errors[0].message).toContain('sky-color-transitionx');
+        expect(errors[0].message).toContain('not-a-sky-property-transition');
         expect(errors[0].message).toContain('unknown');
+    });
+
+    test('Should return error when a transition value is not a transition', () => {
+        const errors = validateSky({
+            validateSpec: validate,
+            value: {
+                'sky-color': 'blue',
+                'sky-color-transition': {duration: 'slow'}
+            } as any,
+            styleSpec: v8,
+            style: {} as any
+        });
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toContain('sky-color-transition.duration');
     });
 
     test('Should pass if everything is according to spec', () => {

--- a/src/validate/validate_sky.test.ts
+++ b/src/validate/validate_sky.test.ts
@@ -58,6 +58,34 @@ describe('Validate sky', () => {
         expect(errors[3].message).toBe('fog-ground-blend: number expected, string found');
     });
 
+    test('Should pass when a transition property matches a transitionable sky property', () => {
+        const errors = validateSky({
+            validateSpec: validate,
+            value: {
+                'sky-color': 'blue',
+                'sky-color-transition': {duration: 1000}
+            } as any,
+            styleSpec: v8,
+            style: {} as any
+        });
+        expect(errors).toHaveLength(0);
+    });
+
+    test('Should return error when a transition property does not match a real property', () => {
+        const errors = validateSky({
+            validateSpec: validate,
+            value: {
+                'sky-color': 'blue',
+                'sky-color-transitionx': {duration: 1000}
+            } as any,
+            styleSpec: v8,
+            style: {} as any
+        });
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toContain('sky-color-transitionx');
+        expect(errors[0].message).toContain('unknown');
+    });
+
     test('Should pass if everything is according to spec', () => {
         const errors = validateSky({
             validateSpec: validate,

--- a/src/validate/validate_sky.ts
+++ b/src/validate/validate_sky.ts
@@ -26,7 +26,23 @@ export function validateSky(options: ValidateSkyOptions) {
 
     let errors = [];
     for (const key in sky) {
-        if (skySpec[key]) {
+        const transitionMatch = key.match(/^(.*)-transition$/);
+
+        if (
+            transitionMatch &&
+            skySpec[transitionMatch[1]] &&
+            skySpec[transitionMatch[1]].transition
+        ) {
+            errors = errors.concat(
+                options.validateSpec({
+                    key,
+                    value: sky[key],
+                    valueSpec: styleSpec.transition,
+                    style,
+                    styleSpec
+                })
+            );
+        } else if (skySpec[key]) {
             errors = errors.concat(
                 options.validateSpec({
                     key,

--- a/src/validate/validate_sky.ts
+++ b/src/validate/validate_sky.ts
@@ -1,5 +1,6 @@
 import {ValidationError} from '../error/validation_error';
 import {getType} from '../util/get_type';
+import {transitionPropertyRegExp} from '../util/properties';
 import v8 from '../reference/v8.json' with {type: 'json'};
 import {SkySpecification, StyleSpecification} from '../types.g';
 
@@ -26,7 +27,7 @@ export function validateSky(options: ValidateSkyOptions) {
 
     let errors = [];
     for (const key in sky) {
-        const transitionMatch = key.match(/^(.*)-transition$/);
+        const transitionMatch = key.match(transitionPropertyRegExp);
 
         if (
             transitionMatch &&


### PR DESCRIPTION
`validateSky` reports `sky-color-transition` and the other `*-transition` keys as unknown properties, although the spec marks the sky properties as `transition: true`. Through maplibre-gl-js that makes `map.setSky({'sky-color': 'blue', 'sky-color-transition': {duration: 1000}})` a silent no-op (maplibre/maplibre-gl-js#8375).

**Cause.** `validate_sky.ts` has only the `skySpec[key]` branch. `validate_light.ts` additionally matches `^(.*)-transition$` and validates the value against `styleSpec.transition` when the base property allows transitions.

**Change.** The same branch in `validateSky`, before the plain property check. Changelog entry under `## main`.

**Proof.** `validate_sky.test.ts` gains two cases: a transition on a transitionable property validates cleanly, and a `-transition` key whose base property does not exist is still reported as unknown. The first fails on `main` with `unknown property "sky-color-transition"` and passes here. `npm run test-unit` (646 tests) and `npm run lint` are green.

Related: maplibre/maplibre-gl-js#8375. The gl-js side (validating before the stylesheet is written, and routing sky errors to the map) is maplibre/maplibre-gl-js#8385.

## Launch Checklist

 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.

Disclosure per the MapLibre AI policy: the change was prepared with AI assistance under my direction; I reviewed every line and am responsible for it.

