### PR TITLE
docs: record semiliteral support in GL JS 6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Record `semiliteral` support in MapLibre GL JS 6.6.0.
 - _...Add new stuff here..._
 
 ## 26.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- Record `semiliteral` support in MapLibre GL JS 6.6.0.
 - _...Add new stuff here..._
 
 ## 26.4.2

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -3518,7 +3518,7 @@
         "group": "Types",
         "sdk-support": {
           "basic functionality": {
-            "js": "https://github.com/maplibre/maplibre-gl-js/issues/7933",
+            "js": "6.6.0",
             "android": "https://github.com/maplibre/maplibre-native/issues/4401",
             "ios": "https://github.com/maplibre/maplibre-native/issues/4401"
           }


### PR DESCRIPTION
Records `semiliteral` support starting with MapLibre GL JS 6.6.0 in the SDK support table.

Verified against the released lockfiles: [v6.5.0](https://github.com/maplibre/maplibre-gl-js/blob/v6.5.0/package-lock.json) bundles style-spec 26.2.1; [v6.6.0](https://github.com/maplibre/maplibre-gl-js/blob/v6.6.0/package-lock.json) bundles 26.3.0, which introduced `semiliteral` in #951. [GL JS 6.6.0 was released on August 24, 2026](https://github.com/maplibre/maplibre-gl-js/releases/tag/v6.6.0).

Related: maplibre/maplibre-gl-js#7933 and [Native follow-up](https://github.com/maplibre/maplibre-native/pull/4604#issuecomment-5628396556).

## Launch Checklist

- [x] No Mapbox backports.
- [x] Describe changes and link related issues.
- [x] Validation: documentation generation, package build, 2,223 integration tests, and `git diff --check` passed. Inspected the generated support table.

AI assistance: prepared with GPT-6 in Codex.

