### PR TITLE
docs: prepare semiliteral native SDK support (android release pending)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
-- Record `semiliteral` support in MapLibre Android 13.7.0 and MapLibre iOS 6.31.0.
 - _...Add new stuff here..._
 
 ## 26.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes
+- Record `semiliteral` support in MapLibre Android 13.7.0 and MapLibre iOS 6.31.0.
 - _...Add new stuff here..._
 
 ## 26.4.2

--- a/src/reference/v8.json
+++ b/src/reference/v8.json
@@ -3519,8 +3519,8 @@
         "sdk-support": {
           "basic functionality": {
             "js": "https://github.com/maplibre/maplibre-gl-js/issues/7933",
-            "android": "https://github.com/maplibre/maplibre-native/issues/4401",
-            "ios": "https://github.com/maplibre/maplibre-native/issues/4401"
+            "android": "13.7.0",
+            "ios": "6.31.0"
           }
         }
       },


### PR DESCRIPTION
Prepares the `semiliteral` SDK support table for MapLibre Android and iOS following the merge of maplibre/maplibre-native#4604.

**Release pending: Android 13.7.0 and iOS 6.31.0 are provisional guesses. Keep this PR in draft until both SDKs ship, then verify and correct the versions in the table before merging.**

- [ ] Verify the first Android release containing #4604 and update `13.7.0` if needed.
- [x] Verify the first iOS release containing #4604 and update `6.31.0` if needed.

Related: maplibre/maplibre-native#4401 and [release follow-up](https://github.com/maplibre/maplibre-native/pull/4604#issuecomment-5628396556).

## Launch Checklist

- [x] No Mapbox backports.
- [x] Describe changes and link related issues.
- [x] Validation: documentation generation, package build, 2,223 integration tests, and `git diff --check` passed. Inspected the generated support table.

AI assistance: prepared with GPT-6 in Codex.

